### PR TITLE
Unify apis to accept external args

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,11 @@ while (strings.next()) |maybe_str| {
 ```
 
 ### Where
-Filter the elements in your iterator, creating a new iterator with only those elements. If you simply need to iterate with a filter, use `filterNext(...)`.
+Filter the elements in your iterator, creating a new iterator with only those elements.
+If you simply need to iterate with a filter, use `filterNext(...)`.
+
+Because this function takes in arguments and works as a quasi-closure, an allocation must be made, so be sure to call `deinit()`.
+If no arguments are passed in or for one-time-use, `whereStatic()` accepts the same arguments but doesn't make an allocation.
 ```zig
 var iter: Iter(u32) = .from(&[_]u32{ 1, 2, 3, 4, 5 });
 
@@ -365,7 +369,9 @@ const isEven = struct {
     }
 }.isEven;
 
-var evens = iter.where(isEven);
+var evens = try iter.where(@import("std").testing.allocator, isEven, {});
+defer evens.deinit();
+
 while (evens.next()) |x| {
     // 2, 4
 }
@@ -413,9 +419,9 @@ const isEven = struct {
 
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 // peek without filter
-_ = iter.any(null); // 1
+_ = iter.any(null, {}); // 1
 // peek with filter
-_ = iter.any(isEven); // 2
+_ = iter.any(isEven, {}); // 2
 
 // iter hasn't moved
 _ = iter.next(); // 1
@@ -437,13 +443,13 @@ const isEven = struct {
 test "filterNext()" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
     var moved: usize = undefined;
-    try testing.expectEqual(2, iter.filterNext(isEven, &moved));
+    try testing.expectEqual(2, iter.filterNext(isEven, {}, &moved));
     try testing.expectEqual(2, moved); // moved 2 elements (1, then 2)
 
-    try testing.expectEqual(null, iter.filterNext(isEven, &moved));
+    try testing.expectEqual(null, iter.filterNext(isEven, {}, &moved));
     try testing.expectEqual(1, moved); // moved 1 element and then encountered end
 
-    try testing.expectEqual(null, iter.filterNext(isEven, &moved));
+    try testing.expectEqual(null, iter.filterNext(isEven, {}, &moved));
     try testing.expectEqual(0, moved); // did not move again
 }
 ```
@@ -510,10 +516,10 @@ const isEven = struct {
     }
 }.isEven;
 
-const evens = iter.where(isEven);
+const evens = iter.whereStatic(isEven, {});
 _ = evens.len(); // length is 5
-_ = evens.count(null); // there are actually 2 elements that fulfill our condition
-_ = iter.count(isEven); // 2 again
+_ = evens.count(null, {}); // there are actually 2 elements that fulfill our condition
+_ = iter.count(isEven, {}); // 2 again
 ```
 
 ### All
@@ -526,40 +532,40 @@ const isEven = struct {
 }.isEven;
 
 var iter: Iter(u8) = .from(&[_]u8{ 2, 4, 6 });
-_ = iter.all(isEven); // true
+_ = iter.all(isEven, {}); // true
 ```
 
 ### Single Or Null
 Determine if exactly 1 or 0 elements fulfill a condition or are left in the iteration. Scrolls back in place.
 ```zig
 var iter: Iter(u8) = .from("1");
-_ = iter.singleOrNull(null); // "1"
+_ = iter.singleOrNull(null, {}); // "1"
 
 var iter2: Iter(u8) = .from("12");
-_ = iter.singleOrNull(null); // error.MultipleElementsFound
+_ = iter.singleOrNull(null, {}); // error.MultipleElementsFound
 
 var iter3: Iter(u8) = .from("");
-_ = iter.singleOrNull(null); // null
+_ = iter.singleOrNull(null, {}); // null
 ```
 
 ### Single
 Determine if exactly 1 element fulfills a condition or is left in the iteration. Scrolls back in place.
 ```zig
 var iter: Iter(u8) = .from("1");
-_ = iter.single(null); // "1"
+_ = iter.single(null, {}); // "1"
 
 var iter2: Iter(u8) = .from("12");
-_ = iter.single(null); // error.MultipleElementsFound
+_ = iter.single(null, {}); // error.MultipleElementsFound
 
 var iter3: Iter(u8) = .from("");
-_ = iter.single(null); // error.NoElementsFound
+_ = iter.single(null, {}); // error.NoElementsFound
 ```
 
 ### Contains
 Pass in a comparer function. Returns true if any element returns `.eq`. Scrolls back in place.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
-_ = iter.contains(1, iter_z.autoCompare(u8)); // true
+_ = iter.contains(1, iter_z.autoCompare(u8), {}); // true
 ```
 
 ### Enumerate To Buffer

--- a/README.md
+++ b/README.md
@@ -363,19 +363,39 @@ If no arguments are passed in or for one-time-use, `whereStatic()` accepts the s
 ```zig
 var iter: Iter(u32) = .from(&[_]u32{ 1, 2, 3, 4, 5 });
 
-const isEven = struct {
-    fn isEven(item: u32) bool {
-        return @mod(item, 2) == 0;
+const hasNoRemainder = struct {
+    fn hasNoRemainder(item: u32, args: anytype) bool {
+        const divisor: u32 = args;
+        return @mod(item, divisor) == 0;
     }
-}.isEven;
+}.hasNoRemainder;
 
-var evens = try iter.where(@import("std").testing.allocator, isEven, {});
+var evens: Iter(u32) = try iter.where(@import("std").testing.allocator, hasNoRemainder, 2);
 defer evens.deinit();
 
 while (evens.next()) |x| {
     // 2, 4
 }
 ```
+
+### Where Static
+If no arguments are passed in or for one-time-use, `whereStatic()` is ideal instead of `where()`.
+```zig
+var iter: Iter(u32) = .from(&[_]u32{ 1, 2, 3, 4, 5 });
+
+const isEven = struct {
+    fn isEven(item: u32, _: anytype) bool {
+        return @mod(item, 2) == 0;
+    }
+}.isEven;
+
+var evens: Iter(u32) = iter.whereStatic(isEven, {});
+
+while (evens.next()) |x| {
+    // 2, 4
+}
+```
+
 
 ### Order By
 Pass in a comparer function to order your iterator in ascending or descending order.
@@ -412,7 +432,7 @@ while (ordered.next()) |x| {
 Peek at the next element with or without a filter.
 ```zig
 const isEven = struct {
-    fn isEven(item: u32) bool {
+    fn isEven(item: u32, _: anytype) bool {
         return @mod(item, 2) == 0;
     }
 }.isEven;
@@ -435,7 +455,7 @@ NOTE : This is preferred over `where()` when simply iterating with a filter.
 ```zig
 const testing = @import("std").testing;
 const isEven = struct {
-    fn isEven(item: u8) bool {
+    fn isEven(item: u8, _: anytype) bool {
         return @mod(item, 2) == 0;
     }
 }.isEven;
@@ -511,7 +531,7 @@ This differs from `len()` because it will count the exact number of remaining el
 var iter: Iter(u32) = .from(&[_]u32{ 1, 2, 3, 4, 5 });
 
 const isEven = struct {
-    fn isEven(item: u32) bool {
+    fn isEven(item: u32, _: anytype) bool {
         return @mod(item, 2) == 0;
     }
 }.isEven;
@@ -526,7 +546,7 @@ _ = iter.count(isEven, {}); // 2 again
 Determine if all remaining elements fulfill a condition. Scrolls back in place.
 ```zig
 const isEven = struct {
-    fn isEven(item: u32) bool {
+    fn isEven(item: u32, _: anytype) bool {
         return @mod(item, 2) == 0;
     }
 }.isEven;

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ _ = iter.all(isEven, {}); // true
 Determine if exactly 1 or 0 elements fulfill a condition or are left in the iteration. Scrolls back in place.
 ```zig
 var iter: Iter(u8) = .from("1");
-_ = iter.singleOrNull(null, {}); // "1"
+_ = iter.singleOrNull(null, {}); // '1'
 
 var iter2: Iter(u8) = .from("12");
 _ = iter.singleOrNull(null, {}); // error.MultipleElementsFound
@@ -572,7 +572,7 @@ _ = iter.singleOrNull(null, {}); // null
 Determine if exactly 1 element fulfills a condition or is left in the iteration. Scrolls back in place.
 ```zig
 var iter: Iter(u8) = .from("1");
-_ = iter.single(null, {}); // "1"
+_ = iter.single(null, {}); // '1'
 
 var iter2: Iter(u8) = .from("12");
 _ = iter.single(null, {}); // error.MultipleElementsFound
@@ -715,7 +715,8 @@ fn compare(a: T, b: T) std.math.Order {
 ### Auto Sum
 ```zig
 fn sum(a: T, b: T, _: anytype) T {
-    return a + b;
+    // notice that we perform saturating addition
+    return a +| b;
 }
 ```
 

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1573,7 +1573,7 @@ fn createFilteredFromIter(
 
         fn implClone(impl: *anyopaque, alloc: Allocator) Allocator.Error!Iter(T) {
             const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
-            return try cloneFilteredFromIter(T, ArgsType, alloc, self_ptr.iter.*, filter, self_ptr.args);
+            return try cloneFilteredFromIter(T, alloc, self_ptr.iter.*, filter, self_ptr.args);
         }
 
         fn implLen(impl: *anyopaque) usize {

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -622,6 +622,10 @@ pub fn Iter(comptime T: type) type {
 
             // if we over-estimated our length
             if (i < length) {
+                if (allocator.resize(buf, i)) {
+                    return fromSliceOwned(allocator, buf, null);
+                }
+
                 defer allocator.free(buf);
                 return fromSliceOwned(allocator, try allocator.dupe(T, buf[0..i]), null);
             }
@@ -871,6 +875,11 @@ pub fn Iter(comptime T: type) type {
 
             // just the right size: return our buffer
             if (i == self.len()) {
+                return buf;
+            }
+
+            // try to resize first
+            if (allocator.resize(buf, i)) {
                 return buf;
             }
 

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1713,13 +1713,15 @@ fn cloneFilteredFromIter(
 
 /// Generate an auto-sum function, assuming elements are a numeric type (excluding enums).
 /// Args are not evaluated in this function.
-/// Take note that this function does not check for overflow.
+///
+/// Take note that this function performs saturating addition.
+/// Rather than integer overflow, the sum returns `T`'s max value.
 pub fn autoSum(comptime T: type) fn (T, T, anytype) T {
     switch (@typeInfo(T)) {
         .int, .float => {
             return struct {
                 fn sum(a: T, b: T, _: anytype) T {
-                    return a + b;
+                    return a +| b;
                 }
             }.sum;
         },

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -729,14 +729,33 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Returns a filtered iterator, using `self` as a source.
+        /// Don't forget to call `deinit()` since this leverages a quasi-closure.
+        ///
+        /// NOTE : If simply needing to iterate with a filter, `filterNext(...)` is preferred to prevent memory allocation.
+        pub fn where(
+            self: *Self,
+            allocator: Allocator,
+            filter: fn (T, anytype) bool,
+            args: anytype,
+        ) Allocator.Error!Self {
+            return try createFilteredFromIter(T, allocator, self, filter, args);
+        }
+
+        /// Returns a filtered iterator, using `self` as a source.
+        /// To prevent allocating memory, the arguments are stored as a threadlocal static.
+        /// This is for one-time use or for filtering when `args` are void.
+        /// Subsequent calls to this method overwrite `args`.
         ///
         /// NOTE : If simply needing to iterate with a filter, `filterNext(...)` is preferred.
-        pub fn where(self: *Self, filter: fn (T) bool) Self {
+        pub fn whereStatic(self: *Self, filter: fn (T, anytype) bool, args: anytype) Self {
+            const ArgsType = @TypeOf(args);
             const ctx = struct {
+                threadlocal var ctx_args: ArgsType = undefined;
+
                 fn implNext(impl: *anyopaque) ?T {
                     const self_ptr: *Iter(T) = @ptrCast(@alignCast(impl));
                     while (self_ptr.next()) |x| {
-                        if (filter(x)) {
+                        if (filter(x, ctx_args)) {
                             return x;
                         }
                     }
@@ -746,7 +765,7 @@ pub fn Iter(comptime T: type) type {
                 fn implPrev(impl: *anyopaque) ?T {
                     const self_ptr: *Iter(T) = @ptrCast(@alignCast(impl));
                     while (self_ptr.prev()) |x| {
-                        if (filter(x)) {
+                        if (filter(x, ctx_args)) {
                             return x;
                         }
                     }
@@ -781,7 +800,7 @@ pub fn Iter(comptime T: type) type {
 
                 fn implClone(impl: *anyopaque, allocator: Allocator) Allocator.Error!Iter(T) {
                     const self_ptr: *Iter(T) = @ptrCast(@alignCast(impl));
-                    return try cloneFilteredFromIter(T, allocator, self_ptr.*, filter);
+                    return try cloneFilteredFromIter(T, allocator, self_ptr.*, filter, ctx_args);
                 }
 
                 fn implLen(impl: *anyopaque) usize {
@@ -794,6 +813,7 @@ pub fn Iter(comptime T: type) type {
                     self_ptr.deinit();
                 }
             };
+            ctx.ctx_args = args;
 
             const filtered: AnonymousIterable(T) = .{
                 .ptr = self,
@@ -892,7 +912,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Determine if the sequence contains any element with a given filter (or pass in null to simply peek at the next element).
         /// Always scrolls back in place.
-        pub fn any(self: *Self, filter: ?fn (T) bool) ?T {
+        pub fn any(self: *Self, filter: ?fn (T, anytype) bool, args: anytype) ?T {
             if (self.len() == 0) {
                 return null;
             }
@@ -903,7 +923,7 @@ pub fn Iter(comptime T: type) type {
             while (self.next()) |n| {
                 scroll_amt -= 1;
                 if (filter) |filter_fn| {
-                    if (filter_fn(n)) {
+                    if (filter_fn(n, args)) {
                         return n;
                     }
                     continue;
@@ -917,12 +937,17 @@ pub fn Iter(comptime T: type) type {
         /// This does move the iterator forward, which is reported in the out parameter `moved_forward`.
         ///
         /// NOTE : This method is preferred over `where()` when simply iterating with a filter.
-        pub fn filterNext(self: *Self, filter: fn (T) bool, moved_forward: *usize) ?T {
+        pub fn filterNext(
+            self: *Self,
+            filter: fn (T, anytype) bool,
+            args: anytype,
+            moved_forward: *usize,
+        ) ?T {
             var moved: usize = 0;
             defer moved_forward.* = moved;
             while (self.next()) |n| {
                 moved += 1;
-                if (filter(n)) {
+                if (filter(n, args)) {
                     return n;
                 }
             }
@@ -932,7 +957,11 @@ pub fn Iter(comptime T: type) type {
         /// Ensure there is exactly 1 or 0 elements that match the given `filter`.
         ///
         /// Will scroll back in place
-        pub fn singleOrNull(self: *Self, filter: ?fn (T) bool) error{MultipleElementsFound}!?T {
+        pub fn singleOrNull(
+            self: *Self,
+            filter: ?fn (T, anytype) bool,
+            args: anytype,
+        ) error{MultipleElementsFound}!?T {
             if (self.len() == 0) {
                 return null;
             }
@@ -944,7 +973,7 @@ pub fn Iter(comptime T: type) type {
             while (self.next()) |x| {
                 scroll_amt -= 1;
                 if (filter) |filter_fn| {
-                    if (filter_fn(x)) {
+                    if (filter_fn(x, args)) {
                         if (found != null) {
                             return error.MultipleElementsFound;
                         } else {
@@ -968,9 +997,10 @@ pub fn Iter(comptime T: type) type {
         /// Will scroll back in place
         pub fn single(
             self: *Self,
-            filter: ?fn (T) bool,
+            filter: ?fn (T, anytype) bool,
+            args: anytype,
         ) error{ NoElementsFound, MultipleElementsFound }!T {
-            return try self.singleOrNull(filter) orelse return error.NoElementsFound;
+            return try self.singleOrNull(filter, args) orelse return error.NoElementsFound;
         }
 
         /// Run `action` for each element in the iterator
@@ -1009,7 +1039,7 @@ pub fn Iter(comptime T: type) type {
                 // not worried about this static local because it doesn't create an iterator
                 threadlocal var ctx_item: T = undefined;
 
-                fn filter(x: T) bool {
+                fn filter(x: T, _: anytype) bool {
                     return switch (comparer(ctx_item, x)) {
                         .eq => true,
                         else => false,
@@ -1017,13 +1047,13 @@ pub fn Iter(comptime T: type) type {
                 }
             };
             ctx.ctx_item = item;
-            return self.any(ctx.filter) != null;
+            return self.any(ctx.filter, {}) != null;
         }
 
         /// Count the number of filtered items or simply count the items remaining.
         ///
         /// Scrolls back in place.
-        pub fn count(self: *Self, filter: ?fn (T) bool) usize {
+        pub fn count(self: *Self, filter: ?fn (T, anytype) bool, args: anytype) usize {
             if (self.len() == 0) {
                 return 0;
             }
@@ -1035,7 +1065,7 @@ pub fn Iter(comptime T: type) type {
             while (self.next()) |x| {
                 scroll_amt -= 1;
                 if (filter) |filter_fn| {
-                    if (filter_fn(x)) {
+                    if (filter_fn(x, args)) {
                         result += 1;
                     }
                 } else {
@@ -1048,7 +1078,7 @@ pub fn Iter(comptime T: type) type {
         /// Determine whether or not all elements fulfill a given filter.
         ///
         /// Scrolls back in place.
-        pub fn all(self: *Self, filter: fn (T) bool) bool {
+        pub fn all(self: *Self, filter: fn (T, anytype) bool, args: anytype) bool {
             if (self.len() == 0) {
                 return true;
             }
@@ -1058,7 +1088,7 @@ pub fn Iter(comptime T: type) type {
 
             while (self.next()) |x| {
                 scroll_amt -= 1;
-                if (!filter(x)) {
+                if (!filter(x, args)) {
                     return false;
                 }
             }
@@ -1282,7 +1312,7 @@ pub fn Iter(comptime T: type) type {
     };
 }
 
-fn TransformedIter(comptime T: type, comptime TArgs: type) type {
+fn IterClosure(comptime T: type, comptime TArgs: type) type {
     return struct {
         iter: *Iter(T),
         args: TArgs,
@@ -1290,7 +1320,7 @@ fn TransformedIter(comptime T: type, comptime TArgs: type) type {
     };
 }
 
-fn CloneTransformIter(comptime T: type, comptime TArgs: type) type {
+fn CloneIterArgs(comptime T: type, comptime TArgs: type) type {
     return struct {
         iter: Iter(T),
         args: TArgs,
@@ -1314,7 +1344,7 @@ fn cloneTransformedIter(
     allocator: Allocator,
 ) Allocator.Error!Iter(TOther) {
     const ArgsType = @TypeOf(args);
-    const ptr: *CloneTransformIter(T, ArgsType) = try allocator.create(CloneTransformIter(T, ArgsType));
+    const ptr: *CloneIterArgs(T, ArgsType) = try allocator.create(CloneIterArgs(T, ArgsType));
     ptr.* = .{
         .iter = iter,
         .args = args,
@@ -1323,7 +1353,7 @@ fn cloneTransformedIter(
 
     const ctx = struct {
         fn implNext(impl: *anyopaque) ?TOther {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             if (self_ptr.iter.next()) |x| {
                 return transform(x, self_ptr.args);
             }
@@ -1331,7 +1361,7 @@ fn cloneTransformedIter(
         }
 
         fn implPrev(impl: *anyopaque) ?TOther {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             if (self_ptr.iter.prev()) |x| {
                 return transform(x, self_ptr.args);
             }
@@ -1339,37 +1369,37 @@ fn cloneTransformedIter(
         }
 
         fn implSetIndex(impl: *anyopaque, to: usize) error{NoIndexing}!void {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             try self_ptr.iter.setIndex(to);
         }
 
         fn implReset(impl: *anyopaque) void {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.reset();
         }
 
         fn implScroll(impl: *anyopaque, offset: isize) void {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.scroll(offset);
         }
 
         fn implGetIndex(impl: *anyopaque) ?usize {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             return self_ptr.iter.getIndex();
         }
 
         fn implClone(impl: *anyopaque, alloc: Allocator) Allocator.Error!Iter(TOther) {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             return try cloneTransformedIter(T, TOther, transform, self_ptr.args, self_ptr.iter, alloc);
         }
 
         fn implLen(impl: *anyopaque) usize {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             return self_ptr.iter.len();
         }
 
         fn implDeinit(impl: *anyopaque) void {
-            const self_ptr: *CloneTransformIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.deinit();
             self_ptr.allocator.destroy(self_ptr);
         }
@@ -1401,7 +1431,7 @@ fn createTransformedIter(
     allocator: Allocator,
 ) Allocator.Error!Iter(TOther) {
     const ArgsType = @TypeOf(args);
-    const ptr: *TransformedIter(T, ArgsType) = try allocator.create(TransformedIter(T, ArgsType));
+    const ptr: *IterClosure(T, ArgsType) = try allocator.create(IterClosure(T, ArgsType));
     ptr.* = .{
         .iter = iter,
         .args = args,
@@ -1410,7 +1440,7 @@ fn createTransformedIter(
 
     const ctx = struct {
         fn implNext(impl: *anyopaque) ?TOther {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             if (self_ptr.iter.next()) |x| {
                 return transform(x, self_ptr.args);
             }
@@ -1418,7 +1448,7 @@ fn createTransformedIter(
         }
 
         fn implPrev(impl: *anyopaque) ?TOther {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             if (self_ptr.iter.prev()) |x| {
                 return transform(x, self_ptr.args);
             }
@@ -1426,37 +1456,37 @@ fn createTransformedIter(
         }
 
         fn implSetIndex(impl: *anyopaque, to: usize) error{NoIndexing}!void {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             try self_ptr.iter.setIndex(to);
         }
 
         fn implReset(impl: *anyopaque) void {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.reset();
         }
 
         fn implScroll(impl: *anyopaque, offset: isize) void {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.scroll(offset);
         }
 
         fn implGetIndex(impl: *anyopaque) ?usize {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             return self_ptr.iter.getIndex();
         }
 
         fn implClone(impl: *anyopaque, alloc: Allocator) Allocator.Error!Iter(TOther) {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             return try cloneTransformedIter(T, TOther, transform, self_ptr.args, self_ptr.iter.*, alloc);
         }
 
         fn implLen(impl: *anyopaque) usize {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             return self_ptr.iter.len();
         }
 
         fn implDeinit(impl: *anyopaque) void {
-            const self_ptr: *TransformedIter(T, ArgsType) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.deinit();
             self_ptr.allocator.destroy(self_ptr);
         }
@@ -1479,23 +1509,26 @@ fn createTransformedIter(
     return clone.iter();
 }
 
-fn cloneFilteredFromIter(
+fn createFilteredFromIter(
     comptime T: type,
     allocator: Allocator,
-    iter: Iter(T),
-    filter: fn (T) bool,
+    iter: *Iter(T),
+    filter: fn (T, anytype) bool,
+    args: anytype,
 ) Allocator.Error!Iter(T) {
-    const ptr: *CloneIter(T) = try allocator.create(CloneIter(T));
+    const ArgsType = @TypeOf(args);
+    const ptr: *IterClosure(T, ArgsType) = try allocator.create(IterClosure(T, ArgsType));
     ptr.* = .{
         .iter = iter,
         .allocator = allocator,
+        .args = args,
     };
 
     const ctx = struct {
         fn implNext(impl: *anyopaque) ?T {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             while (self_ptr.iter.next()) |x| {
-                if (filter(x)) {
+                if (filter(x, self_ptr.args)) {
                     return x;
                 }
             }
@@ -1503,9 +1536,9 @@ fn cloneFilteredFromIter(
         }
 
         fn implPrev(impl: *anyopaque) ?T {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             while (self_ptr.iter.prev()) |x| {
-                if (filter(x)) {
+                if (filter(x, self_ptr.args)) {
                     return x;
                 }
             }
@@ -1517,12 +1550,12 @@ fn cloneFilteredFromIter(
         }
 
         fn implReset(impl: *anyopaque) void {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.reset();
         }
 
         fn implScroll(impl: *anyopaque, offset: isize) void {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             if (offset > 0) {
                 for (0..@bitCast(offset)) |_| {
                     _ = self_ptr.iter.next();
@@ -1539,23 +1572,124 @@ fn cloneFilteredFromIter(
         }
 
         fn implClone(impl: *anyopaque, alloc: Allocator) Allocator.Error!Iter(T) {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
-            return try cloneFilteredFromIter(T, alloc, self_ptr.iter, filter);
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
+            return try cloneFilteredFromIter(T, ArgsType, alloc, self_ptr.iter.*, filter, self_ptr.args);
         }
 
         fn implLen(impl: *anyopaque) usize {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             return self_ptr.iter.len();
         }
 
         fn implDeinit(impl: *anyopaque) void {
-            const self_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const self_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
             self_ptr.iter.deinit();
             self_ptr.allocator.destroy(self_ptr);
         }
 
         fn implDeinitAsClone(impl: *anyopaque) void {
-            const clone_ptr: *CloneIter(T) = @ptrCast(@alignCast(impl));
+            const clone_ptr: *IterClosure(T, ArgsType) = @ptrCast(@alignCast(impl));
+            clone_ptr.allocator.destroy(clone_ptr);
+        }
+    };
+
+    const clone: AnonymousIterable(T) = .{
+        .ptr = ptr,
+        .v_table = &.{
+            .next_fn = &ctx.implNext,
+            .prev_fn = &ctx.implPrev,
+            .set_index_fn = &ctx.implSetIndex,
+            .reset_fn = &ctx.implReset,
+            .scroll_fn = &ctx.implScroll,
+            .get_index_fn = &ctx.implGetIndex,
+            .clone_fn = &ctx.implClone,
+            .len_fn = &ctx.implLen,
+            .deinit_fn = &ctx.implDeinit,
+        },
+    };
+    return clone.iter();
+}
+
+fn cloneFilteredFromIter(
+    comptime T: type,
+    allocator: Allocator,
+    iter: Iter(T),
+    filter: fn (T, anytype) bool,
+    args: anytype,
+) Allocator.Error!Iter(T) {
+    const ArgsType = @TypeOf(args);
+    const ptr: *CloneIterArgs(T, ArgsType) = try allocator.create(CloneIterArgs(T, ArgsType));
+    ptr.* = .{
+        .iter = iter,
+        .allocator = allocator,
+        .args = args,
+    };
+
+    const ctx = struct {
+        fn implNext(impl: *anyopaque) ?T {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            while (self_ptr.iter.next()) |x| {
+                if (filter(x, self_ptr.args)) {
+                    return x;
+                }
+            }
+            return null;
+        }
+
+        fn implPrev(impl: *anyopaque) ?T {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            while (self_ptr.iter.prev()) |x| {
+                if (filter(x, self_ptr.args)) {
+                    return x;
+                }
+            }
+            return null;
+        }
+
+        fn implSetIndex(_: *anyopaque, _: usize) error{NoIndexing}!void {
+            return error.NoIndexing;
+        }
+
+        fn implReset(impl: *anyopaque) void {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            self_ptr.iter.reset();
+        }
+
+        fn implScroll(impl: *anyopaque, offset: isize) void {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            if (offset > 0) {
+                for (0..@bitCast(offset)) |_| {
+                    _ = self_ptr.iter.next();
+                }
+            } else if (offset < 0) {
+                for (0..@bitCast(@abs(offset))) |_| {
+                    _ = self_ptr.iter.prev();
+                }
+            }
+        }
+
+        fn implGetIndex(_: *anyopaque) ?usize {
+            return null;
+        }
+
+        fn implClone(impl: *anyopaque, alloc: Allocator) Allocator.Error!Iter(T) {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            return try cloneFilteredFromIter(T, alloc, self_ptr.iter, filter, self_ptr.args);
+        }
+
+        fn implLen(impl: *anyopaque) usize {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            return self_ptr.iter.len();
+        }
+
+        fn implDeinit(impl: *anyopaque) void {
+            const self_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
+            self_ptr.iter.deinit();
+            self_ptr.allocator.destroy(self_ptr);
+        }
+
+        fn implDeinitAsClone(impl: *anyopaque) void {
+            const clone_ptr: *CloneIterArgs(T, ArgsType) = @ptrCast(@alignCast(impl));
             clone_ptr.allocator.destroy(clone_ptr);
         }
     };

--- a/src/util.zig
+++ b/src/util.zig
@@ -87,7 +87,7 @@ pub fn quickSort(
     comparer: fn (T, T) std.math.Order,
     ordering: Ordering,
 ) void {
-    quickSortSegment(T, slice, 0, slice.len - 1, comparer, ordering);
+    quickSortSegment(T, slice, 0, slice.len -| 1, comparer, ordering);
 }
 
 /// Quick sort implementation, except specifying a segment of `slice` to sort

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -166,6 +166,23 @@ test "where static" {
         try testing.expect(clone2.next() == null);
     }
 }
+test "where" {
+    var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3, 4, 5, 6 });
+    var filtered: Iter(u8) = try iter.where(testing.allocator, isEven, {});
+    defer filtered.deinit();
+
+    var clone: Iter(u8) = try filtered.clone(testing.allocator);
+    defer clone.deinit();
+
+    try testing.expectEqual(2, filtered.next());
+    try testing.expectEqual(2, clone.next());
+    try testing.expectEqual(4, filtered.next());
+    try testing.expectEqual(4, clone.next());
+    try testing.expectEqual(6, filtered.next());
+    try testing.expectEqual(6, clone.next());
+    try testing.expectEqual(null, filtered.next());
+    try testing.expectEqual(null, clone.next());
+}
 test "enumerateToOwnedSlice" {
     var inner: Iter(u8) = .from(&try util.range(u8, 1, 3));
     var iter: Iter(u8) = inner.whereStatic(isEven, {});

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -201,7 +201,7 @@ test "enumerateToOwnedSlice" {
     const slice: []u8 = try iter.enumerateToOwnedSlice(testing.allocator);
     defer testing.allocator.free(slice);
 
-    try testing.expect(slice.len == 1);
+    try testing.expectEqual(1, slice.len);
     try testing.expect(slice[0] == 2);
 }
 test "empty" {


### PR DESCRIPTION
Primarily changing the API's around filtering so that they accept external args. Added `whereStatic()`. Also corrected an integer underflow bug when quick-sorting an empty slice. Also resizing buffers when enumerating to slice before simply duplicating a slice and freeing the original.