### PR TITLE
Multi array list iter

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,27 +806,47 @@ If you wish to start from the beginning, make sure to call `reset()`.
 You are free to create your own iterator!
 You only need to implement `AnonymousIterable(T)`, and call `iter()` on it, which will result in a `Iter(T)`, using your definition.
 ```zig
+/// Virtual table of functions leveraged by the anonymous variant of `Iter(T)`
 pub fn VTable(comptime T: type) type {
     return struct {
-        // zig fmt: off
-        next_fn:            *const fn (*anyopaque) ?T,
-        prev_fn:            *const fn (*anyopaque) ?T,
-        reset_fn:           *const fn (*anyopaque) void,
-        scroll_fn:          *const fn (*anyopaque, isize) void,
-        get_index_fn:       *const fn (*anyopaque) ?usize,
-        set_index_fn:       *const fn (*anyopaque, usize) error{NoIndexing}!void,
-        clone_fn:           *const fn (*anyopaque, Allocator) Allocator.Error!Iter(T),
-        len_fn:             *const fn (*anyopaque) usize,
-        deinit_fn:          *const fn (*anyopaque) void,
-        // zig fmt: on
+        /// Get the next element or null if iteration is over
+        next_fn: *const fn (*anyopaque) ?T,
+        /// Get the previous element or null if the iteration is at beginning
+        prev_fn: *const fn (*anyopaque) ?T,
+        /// Reset the iterator the beginning
+        reset_fn: *const fn (*anyopaque) void,
+        /// Scroll to a relative offset from the iterator's current offset
+        scroll_fn: *const fn (*anyopaque, isize) void,
+        /// Get the index of the iterator, if availalble. Certain transformations obscure this (such as filtering) and this will be null
+        get_index_fn: *const fn (*anyopaque) ?usize,
+        /// Set the index if indexing is supported. Otherwise, should return `error.NoIndexing`
+        set_index_fn: *const fn (*anyopaque, usize) error{NoIndexing}!void,
+        /// Clone into a new iterator, which results in separate state (e.g. two or more iterators on the same slice)
+        clone_fn: *const fn (*anyopaque, Allocator) Allocator.Error!Iter(T),
+        /// Get the maximum number of elements that an iterator will return.
+        /// Note this may not reflect the actual number of elements returned if the iterator is pared down (via filtering).
+        len_fn: *const fn (*anyopaque) usize,
+        /// Deinitialize and free memory as needed
+        deinit_fn: *const fn (*anyopaque) void,
     };
 }
+
 /// User may implement this interface to define their own `Iter(T)`
 pub fn AnonymousIterable(comptime T: type) type {
     return struct {
+        /// Type-erased pointer to implementation
         ptr: *anyopaque,
+        /// Function pointers to the specific implementation functions
         v_table: *const VTable(T),
 
-        // methods...
+        const Self = @This();
+
+        /// Convert to `Iter(T)`
+        pub fn iter(self: Self) Iter(T) {
+            return .{
+                .variant = Iter(T).Variant{ .anonymous = self },
+            };
+        }
+    };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ while (iter.next()) |x| {
 }
 ```
 
+### From Multi
+Initialize an `Iter(T)` from a `MultiArrayList(T)`.
+Keep in mind that the resulting iterator does not own the backing list.
+
 ### From Other
 Initialize an `Iter(T)` from any object, provided it has a `next()` method that returns `?T`.
 Unfortunately, it's not very efficient since we have to enumerate the whole thing to a slice and return an `Iter(T)` that owns that slice.

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 pub const util = @import("util.zig");
 const Allocator = std.mem.Allocator;
+const MultiArrayList = std.MultiArrayList;
 
 pub const Ordering = enum { asc, desc };
 
@@ -209,6 +210,13 @@ fn SliceIterableArgs(comptime T: type, comptime TArgs: type, on_deinit: fn ([]T,
             };
             return anon.iter();
         }
+    };
+}
+
+fn MultiArrayListIterable(comptime T: type) type {
+    return struct {
+        list: MultiArrayList(T),
+        idx: usize = 0,
     };
 }
 

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -232,6 +232,7 @@ pub fn MultiArrayListIterable(comptime T: type) type {
             return .{ .list = list };
         }
 
+        /// Convert to `Iter(T)`, using the pointer to `Self` as the implementation of the `AnonymousIterable(T)` interface.
         pub fn iter(self: *Self) Iter(T) {
             const ctx = struct {
                 fn implNext(impl: *anyopaque) ?T {

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -215,14 +215,19 @@ fn SliceIterableArgs(comptime T: type, comptime TArgs: type, on_deinit: fn ([]T,
     };
 }
 
+/// Structure that is an "iterable", meaning it is easily turned into an implementation of `Iter(T)` through the `AnonymousIterable(T)` interface.
 pub fn MultiArrayListIterable(comptime T: type) type {
     return struct {
+        /// `MultiArrayList(T)` we're iterating through
         list: MultiArrayList(T),
+        /// Current index
         idx: usize = 0,
+        /// If not null, we assume that we own `*Self` and will promptly destroy the pointer on `deinit()`.
         allocator: ?Allocator = null,
 
         const Self = @This();
 
+        /// Initialize from a multi array list
         pub fn init(list: MultiArrayList(T)) Self {
             return .{ .list = list };
         }
@@ -627,7 +632,7 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Create an iterator for a multi-array list. Keep in mind that the iterator does not own the backing list.
-        /// If you do not wish to allocate a pointer, you can initialize a`MultiArrayListIterable(T)` and call `iter()` on it to return the `Iter(T)` interface.
+        /// If you do not wish to allocate a pointer, you can initialize a `MultiArrayListIterable(T)` and call `iter()` on it to return the `Iter(T)` interface.
         /// Recommended if you simply need an iterator in a local scope.
         ///
         /// Note that if you use this method, the resulting `Iter(T)` must be freed with `deinit()`.

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -7,6 +7,7 @@ const Allocator = std.mem.Allocator;
 const SplitIterator = std.mem.SplitIterator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const FixedBufferAllocator = std.heap.FixedBufferAllocator;
+const MultiArrayList = std.MultiArrayList;
 
 fn numToStr(num: u8, allocator: anytype) Allocator.Error![]u8 {
     return try std.fmt.allocPrint(@as(Allocator, allocator), "{d}", .{num});
@@ -972,4 +973,36 @@ test "reverse reset" {
     try testing.expectEqual(3, reversed.next().?);
     // clone should not have changed
     try testing.expectEqual(null, reversed_clone.next());
+}
+test "multi array list" {
+    const S = struct {
+        tag: usize,
+        str: []const u8,
+    };
+
+    var list: MultiArrayList(S) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
+    try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
+
+    var iter: Iter(S) = try .fromMulti(testing.allocator, list);
+    defer iter.deinit();
+
+    var expected_tag: usize = 1;
+    while (iter.next()) |s| : (expected_tag += 1) {
+        try testing.expectEqual(expected_tag, s.tag);
+    }
+    expected_tag = 2;
+    while (iter.prev()) |s| : (expected_tag -= 1) {
+        try testing.expectEqual(expected_tag, s.tag);
+    }
+
+    var clone: Iter(S) = try iter.clone(testing.allocator);
+    defer clone.deinit();
+
+    _ = iter.next();
+    try testing.expectEqualStrings("AAA", clone.next().?.str);
+    try testing.expectEqualStrings("BBB", clone.next().?.str);
+    try testing.expectEqual(1, iter.getIndex());
+    try testing.expectEqual(2, clone.getIndex());
 }

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -980,29 +980,60 @@ test "multi array list" {
         str: []const u8,
     };
 
-    var list: MultiArrayList(S) = .empty;
-    defer list.deinit(testing.allocator);
-    try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
-    try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
+    {
+        var list: MultiArrayList(S) = .empty;
+        defer list.deinit(testing.allocator);
+        try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
+        try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
 
-    var iter: Iter(S) = try .fromMulti(testing.allocator, list);
-    defer iter.deinit();
+        var iter: Iter(S) = try .fromMulti(testing.allocator, list);
+        defer iter.deinit();
 
-    var expected_tag: usize = 1;
-    while (iter.next()) |s| : (expected_tag += 1) {
-        try testing.expectEqual(expected_tag, s.tag);
+        var expected_tag: usize = 1;
+        while (iter.next()) |s| : (expected_tag += 1) {
+            try testing.expectEqual(expected_tag, s.tag);
+        }
+        expected_tag = 2;
+        while (iter.prev()) |s| : (expected_tag -= 1) {
+            try testing.expectEqual(expected_tag, s.tag);
+        }
+
+        var clone: Iter(S) = try iter.clone(testing.allocator);
+        defer clone.deinit();
+
+        _ = iter.next();
+        try testing.expectEqualStrings("AAA", clone.next().?.str);
+        try testing.expectEqualStrings("BBB", clone.next().?.str);
+        try testing.expectEqual(1, iter.getIndex());
+        try testing.expectEqual(2, clone.getIndex());
     }
-    expected_tag = 2;
-    while (iter.prev()) |s| : (expected_tag -= 1) {
-        try testing.expectEqual(expected_tag, s.tag);
+    // use locally scoped iterable
+    {
+        var list: MultiArrayList(S) = .empty;
+        defer list.deinit(testing.allocator);
+        try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
+        try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
+
+        var iterable: iter_z.MultiArrayListIterable(S) = .init(list);
+        var iter: Iter(S) = iterable.iter();
+        // don't need to deinit
+
+        var expected_tag: usize = 1;
+        while (iter.next()) |s| : (expected_tag += 1) {
+            try testing.expectEqual(expected_tag, s.tag);
+        }
+        expected_tag = 2;
+        while (iter.prev()) |s| : (expected_tag -= 1) {
+            try testing.expectEqual(expected_tag, s.tag);
+        }
+
+        var clone: Iter(S) = try iter.clone(testing.allocator);
+        defer clone.deinit();
+
+        _ = iter.next();
+        try testing.expectEqualStrings("AAA", clone.next().?.str);
+        try testing.expectEqualStrings("BBB", clone.next().?.str);
+        try testing.expectEqual(1, iter.getIndex());
+        try testing.expectEqual(2, clone.getIndex());
     }
-
-    var clone: Iter(S) = try iter.clone(testing.allocator);
-    defer clone.deinit();
-
-    _ = iter.next();
-    try testing.expectEqualStrings("AAA", clone.next().?.str);
-    try testing.expectEqualStrings("BBB", clone.next().?.str);
-    try testing.expectEqual(1, iter.getIndex());
-    try testing.expectEqual(2, clone.getIndex());
 }


### PR DESCRIPTION
Introducing an iterable for multi array list. If you find yourself trying to following data-oriented-design strategies, you may run into this gap. Although it may not be as pliable as the slice iterable, it still provides a lot of usefulness, especially to be able to `filterNext()`. I toyed with it having its own dedicated variant, but it's not possible to compile that because `T` must be a structure or union. So... had to go the anonymous iterable route, which was slightly disappointing since that may require allocation.

Also, some breaking changes on the `AnonymousIterable(T)` and VTable structures:
- Removing all methods from `AnonymousIterable(T)` except for `iter()`, which removes duplicate code. And by design, it just doesn't make sense to call the other methods from the anonymous variant when it's plainly available through the `Iter(T)` interface.
- `VTable` became `VTable(T)` and was extracted from `AnonymousIterable(T)` for a potential future redesign on the APIs (0.2.0 territory). I'd like to see if we can imitate the context pattern that std lib uses for sorting to get away from allocating. In general, moving away from allocating pointers to implementations is something I'd like to do, moving toward static dispatch, but we'll see. Gotta get to some experimentation.