### PR TITLE
Simplify multi array list iterator source

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ zig fetch https://github.com/MiahDrao97/iter_z/archive/refs/tags/v0.1.1.tar.gz
 
 ## Iter(T) Methods
 
-### next()
+### `next()`
 Standard iterator method: Returns next element or null if iteration is over.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -84,7 +84,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### prev()
+### `prev()`
 Returns previous element or null if at the beginning.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -98,7 +98,7 @@ _ = iter.prev(); // 2
 _ = iter.prev(); // 1
 ```
 
-### reset()
+### `reset()`
 Reset the iterator to the beginning.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -114,7 +114,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### scroll()
+### `scroll()`
 Scroll left or right by a given offset (negative is left; positive is right).
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -123,7 +123,7 @@ iter.scroll(1); // move next() 1 time
 iter.scroll(-1); // move prev() 1 time
 ```
 
-### setIndex()
+### `setIndex()`
 Set the index of the iterator if it supports indexing. This is only true for iterators created directly from slices.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -133,7 +133,7 @@ try iter.setIndex(2);
 _ = iter.next(); // 3
 ```
 
-### getIndex()
+### `getIndex()`
 Determine if the iterator supports indexing (and consequently has an index).
 ```zig
 const iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -146,14 +146,14 @@ _ = concat_iter.getIndex(); // null
 _ = concat_iter.setIndex(2); // error.NoIndexing
 ```
 
-### len()
+### `len()`
 Maximum length an iterator can be. Generally, it's the same number of elements returned by `next()`, but this length is obscured after undergoing certain transformations such as `where()`.
 ```zig
 const iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.len(); // length is 3
 ```
 
-### clone()
+### `clone()`
 Clone an iterator. This requires creating a new pointer that copies all the data from the cloned iterator. Be sure to call `deinit()`.
 Also, note the method `cloneReset()`, which is a call to clone an iterator and call `reset()` on the clone.
 ```zig
@@ -175,7 +175,7 @@ _ = iter.next(); // 3
 _ = clone2.next(); // 1
 ```
 
-### deinit()
+### `deinit()`
 Free any memory owned by the iterator. Generally, this is a no-op except when an iterator owns a slice or is a clone. However, `deinit()` will turn an iterator into `.empty`, so be aware of that behavior.
 ```zig
 const allocator = @import("std").testing.allocator;
@@ -191,7 +191,9 @@ iter.deinit();
 _ = iter.next(); // null
 ```
 
-## empty
+## Instantiation
+
+### `empty`
 Default iterator with 0 length that always returns `null` on `next()` and `prev()`.
 All calls to `deinit()` turn to into an empty instance.
 ```zig
@@ -200,16 +202,14 @@ _ = iter.next(); // null
 _ = iter.len(); // 0
 ```
 
-## Instantiation
-
-### from()
+### `from()`
 Initializes an `Iter(T)` from a slice. It does not own the slice, and will not affect it while iterating.
 There are examples of this function all over this document.
 
-### fromSliceOwned()
+### `fromSliceOwned()`
 Initializes an `Iter(T)` from a slice, except it owns the slice.
 As a result, calling `deinit()` will free the slice.
-Also, on optional action may be passed in that will be called on the slice when the iterator is deinitialized.
+Also, an optional action may be passed in that will be called on the slice when the iterator is deinitialized.
 This is useful for individually freeing memory for each element.
 ```zig
 const allocator = @import("std").testing.allocator;
@@ -244,7 +244,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### fromMulti()
+### `fromMulti()`
 Initialize an `Iter(T)` from a `MultiArrayList(T)`.
 Keep in mind that the resulting iterator does not own the backing list (and more specifically, it only has a copy to the list, not a const pointer).
 Because of that, some operations don't make a lot of sense through the `Iter(T)` API such as ordering and cloning (the list, not the iterator).
@@ -272,7 +272,7 @@ while (iter.prev()) |s| : (expected_tag -= 1) {
 }
 ```
 
-### fromOther()
+### `fromOther()`
 Initialize an `Iter(T)` from any object, provided it has a `next()` method that returns `?T`.
 Unfortunately, it's not very efficient since we have to enumerate the whole thing to a slice and return an `Iter(T)` that owns that slice.
 However, this gives you access to query methods from iterators returned from other libraries.
@@ -289,7 +289,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### concat()
+### `concat()`
 Concatenate any number of iterators into 1.
 It will iterate in the same order the iterators were passed in.
 Keep in mind that the resulting iterator does not own these sources, so caller must `deinit()` the sources invidually afterward.
@@ -306,7 +306,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### concatOwned()
+### `concatOwned()`
 Just like `concat()`, except the resulting iterator owns the iterators and slice passed in.
 ```zig
 const allocator = @import("std").testing.allocator;
@@ -327,7 +327,7 @@ while (iter.next()) |x| {
 ## Queries
 These are the queries currently available on `Iter(T)`:
 
-### append()
+### `append()`
 Essentially is a simplified call of `concatOwned()`, which merges two iterators into 1.
 ```zig
 const iter_a: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -342,7 +342,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### select()
+### `select()`
 Transform the elements in your iterator from one type `T` to another `TOther`.
 Takes in two arguments after the method receiver: `context_ptr` and `ownership`.
 
@@ -415,7 +415,7 @@ while (strings.next()) |maybe_str| {
 }
 ```
 
-### where()
+### `where()`
 Filter the elements in your iterator, creating a new iterator with only those elements.
 If you simply need to iterate with a filter, use `filterNext(...)`.
 
@@ -472,7 +472,7 @@ while (evens.next()) |x| {
 }
 ```
 
-### orderBy()
+### `orderBy()`
 Pass in a comparer function to order your iterator in ascending or descending order (unstable sorting).
 Keep in mind that this allocates a slice owned by the resulting iterator, so be sure to call `deinit()`.
 Stable sorting is available via `orderByStable()`.
@@ -504,7 +504,7 @@ while (ordered.next()) |x| {
 }
 ```
 
-### any()
+### `any()`
 Peek at the next element with or without a filter.
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
 It does not need to be a pointer since it's not being stored as a member of a structure.
@@ -528,7 +528,7 @@ _ = iter.any(ZeroRemainder{ .divisor = 2 }); // 2
 _ = iter.next(); // 1
 ```
 
-### filterNext()
+### `filterNext()`
 Calls `next()` until an element fulfills the given filter condition or returns null if none are found/iteration is over.
 Writes the number of elements moved forward to the out parameter `moved_forward`.
 
@@ -563,7 +563,7 @@ test "filterNext()" {
 }
 ```
 
-### forEach()
+### `forEach()`
 Execute an action over the elements of your iterator.
 Optionally pass in an action when an error is occurred and determine if iteration should break when an error is encountered.
 ```zig
@@ -622,7 +622,7 @@ try testing.expect(i == 3);
 
 ```
 
-### count()
+### `count()`
 Count the number of elements in your iterator with or without a filter.
 This differs from `len()` because it will count the exact number of remaining elements with all transformations applied. Scrolls back in place.
 
@@ -648,7 +648,7 @@ _ = iter.count(null); // 5
 _ = iter.count(filter); // 2
 ```
 
-### all()
+### `all()`
 Determine if all remaining elements fulfill a condition. Scrolls back in place.
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
 It does not need to be a pointer since it's not being stored as a member of a structure.
@@ -663,7 +663,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 2, 4, 6 });
 _ = iter.all(IsEven{}); // true
 ```
 
-### singleOrNull()
+### `singleOrNull()`
 Determine if exactly 1 or 0 elements fulfill a condition or are left in the iteration. Scrolls back in place.
 
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
@@ -680,7 +680,7 @@ var iter3: Iter(u8) = .from("");
 _ = iter3.singleOrNull(null); // null
 ```
 
-### single()
+### `single()`
 Determine if exactly 1 element fulfills a condition or is left in the iteration. Scrolls back in place.
 
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
@@ -697,7 +697,7 @@ var iter3: Iter(u8) = .from("");
 _ = iter3.single(null); // error.NoElementsFound
 ```
 
-### contains()
+### `contains()`
 Pass in a comparer context. Returns true if any element returns `.eq`. Scrolls back in place.
 `context` must define the method `fn compare(@This(), T, T) std.math.Order`.
 ```zig
@@ -705,7 +705,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.contains(1, iter_z.autoCompare(u8)); // true
 ```
 
-### enumerateToBuffer()
+### `enumerateToBuffer()`
 Enumerate all elements to a buffer passed in from the current. If you wish to start at the beginning, be sure to call `reset()`. Returns a slice of the buffer.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -718,7 +718,7 @@ var buf2: [2]u8 = undefined;
 var result: []u8 = iter.enumerateToBuffer(&buf2) catch &buf2; // fails, but results are [ 1, 2 ]
 ```
 
-### enumerateToOwnedSlice()
+### `enumerateToOwnedSlice()`
 Allocate a slice and enumerate all elements to it from the current offset.
 This will not free the iterator if it owns any memory, so you'll still have to call `deinit()` on it if it does.
 Caller owns the slice. If you wish to start enumerating at the beginning, be sure to call `reset()`.
@@ -730,7 +730,7 @@ const results: []u8 = try iter.enumerateToOwnedSlice(allocator);
 defer allocator.free(results);
 ```
 
-### fold()
+### `fold()`
 Fold the iteration into a single value of a given type.
 An initial value is fed into the context's `accumulate()` method with the current item, and the result is assigned to a collector value.
 That collector value is continued is each subsequent call to `accumulate()` with each element in the iterator, reassigning its value the result until the end of the enumeration.
@@ -753,7 +753,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.fold(u16, Sum{}, 0); // 6
 ```
 
-### reduce()
+### `reduce()`
 Calls `fold()`, using the first element as the collector value.
 The return type will be the same as the element type.
 If there are no elements or iteration is over, will return null.
@@ -770,7 +770,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.reduce(Sum{}); // 6
 ```
 
-### reverse()
+### `reverse()`
 Reverses the direction of iteration and indexing (if applicable)
 It's as if the end of a slice where its beginning, and its beginning is the end.
 ```zig
@@ -794,7 +794,7 @@ test "reverse" {
 }
 ```
 
-### reverseReset()
+### `reverseReset()`
 Calls `reverse()` and `reset()` on the reversed iterator for ergonomics.
 ```zig
 test "reverse reset" {

--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ _ = clone2.next(); // 1
 ```
 
 ### `deinit()`
-Free any memory owned by the iterator. Generally, this is a no-op except when an iterator owns a slice or is a clone. However, `deinit()` will turn an iterator into `.empty`, so be aware of that behavior.
+Free any memory owned by the iterator. Generally, this is a no-op except when an iterator owns or is a clone.
+However, `deinit()` will assign an iterator into `.empty`, so be aware of that behavior.
+It can be redundantly called as well.
 ```zig
 const allocator = @import("std").testing.allocator;
 
@@ -247,8 +249,11 @@ while (iter.next()) |x| {
 ### `fromMulti()`
 Initialize an `Iter(T)` from a `MultiArrayList(T)`.
 Keep in mind that the resulting iterator does not own the backing list (and more specifically, it only has a copy to the list, not a const pointer).
-Because of that, some operations don't make a lot of sense through the `Iter(T)` API such as ordering and cloning (the list, not the iterator).
-The recommended course of action for both of these is to order and clone the list directly and then initialize a new iterator from the ordered/cloned list afterward.
+Because of that, some operations don't make a lot of sense through the `Iter(T)` API such as ordering.
+The recommended course of action for both of these is to order the list directly and then initialize a new iterator from the ordered list afterward.
+
+`clone()` does not allocate additional memory since the iterator does not own the list. It merely clones the iterator, not the list itself.
+Consequently, `deinit()` will not free the list, and is virtually a no-op since there is no memory to cleanup (still assigns the iterator to `empty`).
 ```zig
 const S = struct {
     tag: usize,
@@ -771,7 +776,7 @@ _ = iter.reduce(Sum{}); // 6
 ```
 
 ### `reverse()`
-Reverses the direction of iteration and indexing (if applicable)
+Reverses the direction of iteration and indexing (if applicable).
 It's as if the end of a slice where its beginning, and its beginning is the end.
 ```zig
 test "reverse" {

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ while (iter.next()) |x| {
 ### `concat()`
 Concatenate any number of iterators into 1.
 It will iterate in the same order the iterators were passed in.
-Keep in mind that the resulting iterator does not own these sources, so caller must `deinit()` the sources invidually afterward.
+Keep in mind that the resulting iterator does not own these sources, so caller may need to `deinit()` the sources invidually afterward.
 ```zig
 var chain = [_]Iter(u8){
     .from(&[_]u8{ 1, 2, 3 }),

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ zig fetch https://github.com/MiahDrao97/iter_z/archive/refs/tags/v0.1.1.tar.gz
 
 ## Iter(T) Methods
 
-### Next
+### next()
 Standard iterator method: Returns next element or null if iteration is over.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -84,7 +84,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### Prev
+### prev()
 Returns previous element or null if at the beginning.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -98,7 +98,7 @@ _ = iter.prev(); // 2
 _ = iter.prev(); // 1
 ```
 
-### Reset
+### reset()
 Reset the iterator to the beginning.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -114,7 +114,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### Scroll
+### scroll()
 Scroll left or right by a given offset (negative is left; positive is right).
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -123,7 +123,7 @@ iter.scroll(1); // move next() 1 time
 iter.scroll(-1); // move prev() 1 time
 ```
 
-### Set Index
+### setIndex()
 Set the index of the iterator if it supports indexing. This is only true for iterators created directly from slices.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -133,7 +133,7 @@ try iter.setIndex(2);
 _ = iter.next(); // 3
 ```
 
-### Get Index
+### getIndex()
 Determine if the iterator supports indexing (and consequently has an index).
 ```zig
 const iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -146,14 +146,14 @@ _ = concat_iter.getIndex(); // null
 _ = concat_iter.setIndex(2); // error.NoIndexing
 ```
 
-### Len
+### len()
 Maximum length an iterator can be. Generally, it's the same number of elements returned by `next()`, but this length is obscured after undergoing certain transformations such as `where()`.
 ```zig
 const iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.len(); // length is 3
 ```
 
-### Clone
+### clone()
 Clone an iterator. This requires creating a new pointer that copies all the data from the cloned iterator. Be sure to call `deinit()`.
 Also, note the method `cloneReset()`, which is a call to clone an iterator and call `reset()` on the clone.
 ```zig
@@ -175,7 +175,7 @@ _ = iter.next(); // 3
 _ = clone2.next(); // 1
 ```
 
-### Deinit
+### deinit()
 Free any memory owned by the iterator. Generally, this is a no-op except when an iterator owns a slice or is a clone. However, `deinit()` will turn an iterator into `.empty`, so be aware of that behavior.
 ```zig
 const allocator = @import("std").testing.allocator;
@@ -191,7 +191,7 @@ iter.deinit();
 _ = iter.next(); // null
 ```
 
-## Empty
+## empty
 Default iterator with 0 length that always returns `null` on `next()` and `prev()`.
 All calls to `deinit()` turn to into an empty instance.
 ```zig
@@ -202,11 +202,11 @@ _ = iter.len(); // 0
 
 ## Instantiation
 
-### From
+### from()
 Initializes an `Iter(T)` from a slice. It does not own the slice, and will not affect it while iterating.
 There are examples of this function all over this document.
 
-### From Slice Owned
+### fromSliceOwned()
 Initializes an `Iter(T)` from a slice, except it owns the slice.
 As a result, calling `deinit()` will free the slice.
 Also, on optional action may be passed in that will be called on the slice when the iterator is deinitialized.
@@ -244,7 +244,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### From Multi
+### fromMulti()
 Initialize an `Iter(T)` from a `MultiArrayList(T)`.
 Keep in mind that the resulting iterator does not own the backing list (and more specifically, it only has a copy to the list, not a const pointer).
 Because of that, some operations don't make a lot of sense through the `Iter(T)` API such as ordering and cloning (the list, not the iterator).
@@ -272,7 +272,7 @@ while (iter.prev()) |s| : (expected_tag -= 1) {
 }
 ```
 
-### From Other
+### fromOther()
 Initialize an `Iter(T)` from any object, provided it has a `next()` method that returns `?T`.
 Unfortunately, it's not very efficient since we have to enumerate the whole thing to a slice and return an `Iter(T)` that owns that slice.
 However, this gives you access to query methods from iterators returned from other libraries.
@@ -289,7 +289,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### Concat
+### concat()
 Concatenate any number of iterators into 1.
 It will iterate in the same order the iterators were passed in.
 Keep in mind that the resulting iterator does not own these sources, so caller must `deinit()` the sources invidually afterward.
@@ -306,7 +306,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### Concat Owned
+### concatOwned()
 Just like `concat()`, except the resulting iterator owns the iterators and slice passed in.
 ```zig
 const allocator = @import("std").testing.allocator;
@@ -327,7 +327,7 @@ while (iter.next()) |x| {
 ## Queries
 These are the queries currently available on `Iter(T)`:
 
-### Append
+### append()
 Essentially is a simplified call of `concatOwned()`, which merges two iterators into 1.
 ```zig
 const iter_a: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -342,7 +342,7 @@ while (iter.next()) |x| {
 }
 ```
 
-### Select
+### select()
 Transform the elements in your iterator from one type `T` to another `TOther`.
 Takes in two arguments after the method receiver: `context_ptr` and `ownership`.
 
@@ -415,7 +415,7 @@ while (strings.next()) |maybe_str| {
 }
 ```
 
-### Where
+### where()
 Filter the elements in your iterator, creating a new iterator with only those elements.
 If you simply need to iterate with a filter, use `filterNext(...)`.
 
@@ -472,7 +472,7 @@ while (evens.next()) |x| {
 }
 ```
 
-### Order By
+### orderBy()
 Pass in a comparer function to order your iterator in ascending or descending order (unstable sorting).
 Keep in mind that this allocates a slice owned by the resulting iterator, so be sure to call `deinit()`.
 Stable sorting is available via `orderByStable()`.
@@ -504,7 +504,7 @@ while (ordered.next()) |x| {
 }
 ```
 
-### Any
+### any()
 Peek at the next element with or without a filter.
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
 It does not need to be a pointer since it's not being stored as a member of a structure.
@@ -528,7 +528,7 @@ _ = iter.any(ZeroRemainder{ .divisor = 2 }); // 2
 _ = iter.next(); // 1
 ```
 
-### Filter Next
+### filterNext()
 Calls `next()` until an element fulfills the given filter condition or returns null if none are found/iteration is over.
 Writes the number of elements moved forward to the out parameter `moved_forward`.
 
@@ -563,7 +563,7 @@ test "filterNext()" {
 }
 ```
 
-### For Each
+### forEach()
 Execute an action over the elements of your iterator.
 Optionally pass in an action when an error is occurred and determine if iteration should break when an error is encountered.
 ```zig
@@ -622,7 +622,7 @@ try testing.expect(i == 3);
 
 ```
 
-### Count
+### count()
 Count the number of elements in your iterator with or without a filter.
 This differs from `len()` because it will count the exact number of remaining elements with all transformations applied. Scrolls back in place.
 
@@ -648,7 +648,7 @@ _ = iter.count(null); // 5
 _ = iter.count(filter); // 2
 ```
 
-### All
+### all()
 Determine if all remaining elements fulfill a condition. Scrolls back in place.
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
 It does not need to be a pointer since it's not being stored as a member of a structure.
@@ -663,7 +663,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 2, 4, 6 });
 _ = iter.all(IsEven{}); // true
 ```
 
-### Single Or Null
+### singleOrNull()
 Determine if exactly 1 or 0 elements fulfill a condition or are left in the iteration. Scrolls back in place.
 
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
@@ -680,7 +680,7 @@ var iter3: Iter(u8) = .from("");
 _ = iter3.singleOrNull(null); // null
 ```
 
-### Single
+### single()
 Determine if exactly 1 element fulfills a condition or is left in the iteration. Scrolls back in place.
 
 The filter context is like the one in `where()`: It must define the method `fn filter(@This(), T) bool`.
@@ -697,7 +697,7 @@ var iter3: Iter(u8) = .from("");
 _ = iter3.single(null); // error.NoElementsFound
 ```
 
-### Contains
+### contains()
 Pass in a comparer context. Returns true if any element returns `.eq`. Scrolls back in place.
 `context` must define the method `fn compare(@This(), T, T) std.math.Order`.
 ```zig
@@ -705,7 +705,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.contains(1, iter_z.autoCompare(u8)); // true
 ```
 
-### Enumerate To Buffer
+### enumerateToBuffer()
 Enumerate all elements to a buffer passed in from the current. If you wish to start at the beginning, be sure to call `reset()`. Returns a slice of the buffer.
 ```zig
 var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
@@ -718,7 +718,7 @@ var buf2: [2]u8 = undefined;
 var result: []u8 = iter.enumerateToBuffer(&buf2) catch &buf2; // fails, but results are [ 1, 2 ]
 ```
 
-### Enumerate To Owned Slice
+### enumerateToOwnedSlice()
 Allocate a slice and enumerate all elements to it from the current offset.
 This will not free the iterator if it owns any memory, so you'll still have to call `deinit()` on it if it does.
 Caller owns the slice. If you wish to start enumerating at the beginning, be sure to call `reset()`.
@@ -730,7 +730,7 @@ const results: []u8 = try iter.enumerateToOwnedSlice(allocator);
 defer allocator.free(results);
 ```
 
-### Fold
+### fold()
 Fold the iteration into a single value of a given type.
 An initial value is fed into the context's `accumulate()` method with the current item, and the result is assigned to a collector value.
 That collector value is continued is each subsequent call to `accumulate()` with each element in the iterator, reassigning its value the result until the end of the enumeration.
@@ -753,7 +753,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.fold(u16, Sum{}, 0); // 6
 ```
 
-### Reduce
+### reduce()
 Calls `fold()`, using the first element as the collector value.
 The return type will be the same as the element type.
 If there are no elements or iteration is over, will return null.
@@ -770,7 +770,7 @@ var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
 _ = iter.reduce(Sum{}); // 6
 ```
 
-### Reverse
+### reverse()
 Reverses the direction of iteration and indexing (if applicable)
 It's as if the end of a slice where its beginning, and its beginning is the end.
 ```zig
@@ -794,7 +794,7 @@ test "reverse" {
 }
 ```
 
-### Reverse Reset
+### reverseReset()
 Calls `reverse()` and `reset()` on the reversed iterator for ergonomics.
 ```zig
 test "reverse reset" {

--- a/README.md
+++ b/README.md
@@ -249,43 +249,19 @@ Initialize an `Iter(T)` from a `MultiArrayList(T)`.
 Keep in mind that the resulting iterator does not own the backing list (and more specifically, it only has a copy to the list, not a const pointer).
 Because of that, some operations don't make a lot of sense through the `Iter(T)` API such as ordering and cloning (the list, not the iterator).
 The recommended course of action for both of these is to order and clone the list directly and then initialize a new iterator from the ordered/cloned list afterward.
-
-There are 2 ways to initialize an iterator from a `MultiArrayList(T)`. One requires no additional allocation, but is limited to local scopes, whereas the other can be safely returned from a function.
 ```zig
 const S = struct {
     tag: usize,
     str: []const u8,
 };
 
-// `fromMulti()` initialization, which allocates a pointer to the implementation of `Iter(T)`
 {
     var list: MultiArrayList(S) = .empty;
     defer list.deinit(testing.allocator);
     try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
     try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
 
-    var iter: Iter(S) = try .fromMulti(testing.allocator, list);
-    defer iter.deinit();
-
-    var expected_tag: usize = 1;
-    while (iter.next()) |s| : (expected_tag += 1) {
-        try testing.expectEqual(expected_tag, s.tag);
-    }
-    expected_tag = 2;
-    while (iter.prev()) |s| : (expected_tag -= 1) {
-        try testing.expectEqual(expected_tag, s.tag);
-    }
-}
-// use locally scoped iterable
-{
-    var list: MultiArrayList(S) = .empty;
-    defer list.deinit(testing.allocator);
-    try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
-    try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
-
-    var iterable: iter_z.MultiArrayListIterable(S) = .init(list);
-    var iter: Iter(S) = iterable.iter();
-    // don't need to deinit
+    var iter: Iter(S) = .fromMulti(list);
 
     var expected_tag: usize = 1;
     while (iter.next()) |s| : (expected_tag += 1) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
     .fingerprint = 0x4415db88c6a4829c,
     .name = .iter_z,
-    .version = "0.2.0",
+    .version = "0.2.1",
     .dependencies = .{},
     .paths = .{""},
+    .minimum_zig_version = "0.14.1",
 }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1025,14 +1025,12 @@ pub fn Iter(comptime T: type) type {
         /// Also scrolls back 1 if we run out of space so that the next element on `self` will be the one that encountered the `NoSpaceLeft` error.
         pub fn enumerateToBuffer(self: *Iter(T), buf: []T) error{NoSpaceLeft}![]T {
             var i: usize = 0;
-            while (self.next()) |x| {
+            while (self.next()) |x| : (i += 1) {
                 if (i >= buf.len) {
                     self.scroll(-1);
                     return error.NoSpaceLeft;
                 }
-
                 buf[i] = x;
-                i += 1;
             }
             return buf[0..i];
         }
@@ -1046,23 +1044,18 @@ pub fn Iter(comptime T: type) type {
             const buf: []T = try allocator.alloc(T, self.len());
 
             var i: usize = 0;
-            while (self.next()) |x| {
+            while (self.next()) |x| : (i += 1) {
                 buf[i] = x;
-                i += 1;
             }
-
             // just the right size: return our buffer
             if (i == buf.len) {
                 return buf;
             }
-
             // try to resize first
             if (allocator.resize(buf, i)) {
                 return buf;
             }
-
             defer allocator.free(buf);
-
             // pair buf down to final slice
             return try allocator.dupe(T, buf[0..i]);
         }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1124,7 +1124,7 @@ pub fn Iter(comptime T: type) type {
                 .ctx = context,
                 .ordering = ordering,
             };
-            std.sort.heap(T, slice, sort_ctx, SortContext(T, @TypeOf(context)).lessThan);
+            std.mem.sortUnstable(T, slice, sort_ctx, SortContext(T, @TypeOf(context)).lessThan);
             return slice;
         }
 
@@ -1147,7 +1147,7 @@ pub fn Iter(comptime T: type) type {
                 .ctx = context,
                 .ordering = ordering,
             };
-            std.sort.insertion(T, slice, sort_ctx, SortContext(T, @TypeOf(context)).lessThan);
+            std.mem.sort(T, slice, sort_ctx, SortContext(T, @TypeOf(context)).lessThan);
             return slice;
         }
 
@@ -1309,7 +1309,7 @@ pub fn Iter(comptime T: type) type {
             context: anytype,
         ) error{ NoElementsFound, MultipleElementsFound }!T {
             _ = validateFilterContext(T, context, .optional);
-            return try self.singleOrNull(context) orelse return error.NoElementsFound;
+            return try self.singleOrNull(context) orelse error.NoElementsFound;
         }
 
         /// Run `action` for each element in the iterator
@@ -1653,7 +1653,6 @@ fn CloneIter(comptime T: type) type {
 }
 
 /// Generate an auto-sum function, assuming elements are a numeric type (excluding enums).
-/// Args are not evaluated in this function.
 ///
 /// Take note that this function performs saturating addition.
 /// Rather than integer overflow, the sum returns `T`'s max value.
@@ -1674,7 +1673,7 @@ fn AutoSumContext(comptime T: type) type {
     }
 }
 
-/// Generate an auto-min function, assuming elements are a numeric type (including enums). Args are not evaluated in this function.
+/// Generate an auto-min function, assuming elements are a numeric type (including enums).
 pub inline fn autoMin(comptime T: type) AutoMinContext(T) {
     return .{};
 }
@@ -1705,7 +1704,7 @@ fn AutoMinContext(comptime T: type) type {
     }
 }
 
-/// Generate an auto-max function, assuming elements are a numeric type (including enums). Args are not evaluated in this function.
+/// Generate an auto-max function, assuming elements are a numeric type (including enums).
 pub inline fn autoMax(comptime T: type) AutoMaxContext(T) {
     return .{};
 }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -183,10 +183,8 @@ fn MultiArrayListIterable(comptime T: type) type {
         /// Current index
         idx: usize = 0,
 
-        const Self = @This();
-
         /// Initialize from a multi array list
-        pub fn init(list: MultiArrayList(T)) Self {
+        pub fn init(list: MultiArrayList(T)) @This() {
             return .{ .list = list };
         }
     };
@@ -622,11 +620,12 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Create an iterator for a multi-array list. Keep in mind that the iterator does not own the backing list.
+        /// Calls to `clone()` and `deinit()` are no-ops.
         pub fn fromMulti(list: MultiArrayList(T)) Iter(T) {
             if (comptime multi_arr_list_allowed) {
                 return .{
                     .variant = Variant{
-                        .multi_arr_list = .init(list),
+                        .multi_arr_list = MultiArrayListIterable(T).init(list),
                     },
                 };
             }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -331,6 +331,9 @@ pub fn Iter(comptime T: type) type {
         else => false,
     };
     return struct {
+        /// Which iterator implementation we're using
+        variant: Variant,
+
         const Variant = union(enum) {
             slice: SliceIterable(T),
             multi_arr_list: if (multi_arr_list_allowed) MultiArrayListIterable(T) else void,
@@ -339,8 +342,6 @@ pub fn Iter(comptime T: type) type {
             context: ContextIterable(T),
             empty: void,
         };
-
-        variant: Variant,
 
         /// Get the next element
         pub fn next(self: *Iter(T)) ?T {
@@ -741,10 +742,11 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Transform an iterator of type `T` to type `TOther`.
-        /// - `context` must be a pointer to a type that defines the method: `fn transform(@This(), T) TOther`.
+        /// - `context_ptr` must be a pointer to a type that defines the method: `fn transform(@This(), T) TOther`.
+        ///   It's stored as a type-erased pointer.
         /// - `ownership` indicates whether or not `context` is owned by this iterator.
-        ///    If you pass in the `owned` tag with the allocator that created the context pointer, it will be destroyed on `deinit()`.
-        ///    Otherwise, pass in `.none` if `context` points to something locally scoped or a constant.
+        ///   If you pass in the `owned` tag with the allocator that created the context pointer, it will be destroyed on `deinit()`.
+        ///   Otherwise, pass in `.none` if `context` points to something locally scoped or a constant.
         ///
         /// Context example:
         /// ```zig
@@ -884,11 +886,11 @@ pub fn Iter(comptime T: type) type {
 
         /// Returns a filtered iterator, using `self` as a source.
         ///
-        /// - `context` must be a *pointer* to a type that defines the method: `fn filter(@This(), T) bool`.
-        ///   That pointer will be stored as a type-erased pointer, hybridizing static and dynamic dispatch.
+        /// - `context_ptr` must be a *pointer* to a type that defines the method: `fn filter(@This(), T) bool`.
+        ///   That pointer will be stored as a type-erased pointer.
         /// - `ownership` indicates whether or not `context` is owned by this iterator.
-        ///    If you pass in the `owned` tag with the allocator that created the context pointer, it will be destroyed on `deinit()`.
-        ///    Otherwise, pass in `.none` if `context` points to something locally scoped or a constant.
+        ///   If you pass in the `owned` tag with the allocator that created the context pointer, it will be destroyed on `deinit()`.
+        ///   Otherwise, pass in `.none` if `context` points to something locally scoped or a constant.
         ///
         /// Context example:
         /// ```zig

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -1,12 +1,10 @@
-const std = @import("std");
-const Allocator = std.mem.Allocator;
-const MultiArrayList = std.MultiArrayList;
-const Fn = std.builtin.Type.Fn;
-const assert = std.debug.assert;
-const DoublyLinkedList = std.DoublyLinkedList;
-pub const util = @import("util.zig");
-
-pub const Ordering = enum { asc, desc };
+//! iter_z namespace:
+//! - `Iter(T)`: primary iterator interface
+//! - `VTable(T)`: functions used by `AnonymousIterable(T)`
+//! - `AnonymousIterable(T)`: extensible structure that uses `VTable(T)` and converts to `Iter(T)`
+//! - `Ordering`: `asc` or `desc`, which are used when sorting
+//! - `ContextOwnership`: used by `select()` or `where()` to denote the context pointer should be owned by the iterator or not
+//! - auto contexts: `autoCompare(T)`, `autoSum(T)`, `autoMin(T)`, `autoMax(T)`
 
 /// Virtual table of functions leveraged by the anonymous variant of `Iter(T)`
 pub fn VTable(comptime T: type) type {
@@ -185,7 +183,7 @@ fn MultiArrayListIterable(comptime T: type) type {
         idx: usize = 0,
 
         /// Initialize from a multi array list
-        pub fn init(list: MultiArrayList(T)) @This() {
+        fn init(list: MultiArrayList(T)) @This() {
             return .{ .list = list };
         }
     };
@@ -659,7 +657,7 @@ pub fn Iter(comptime T: type) type {
             };
         }
 
-        /// Merge several sources into one, except this resulting iterator owns `sources`.
+        /// Merge several sources into one, and this resulting iterator owns `sources`.
         ///
         /// Be sure to call `deinit()` to free.
         pub fn concatOwned(allocator: Allocator, sources: []Iter(T)) Iter(T) {
@@ -1726,6 +1724,9 @@ fn AutoCompareContext(comptime T: type) type {
     }
 }
 
+/// Sort ascending or descending
+pub const Ordering = enum { asc, desc };
+
 fn SortContext(comptime T: type, comptime TContext: type) type {
     return struct {
         ctx: TContext,
@@ -1865,3 +1866,10 @@ inline fn validateCompareContext(comptime T: type, context: anytype) void {
         }
     }
 }
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const MultiArrayList = std.MultiArrayList;
+const Fn = std.builtin.Type.Fn;
+const assert = std.debug.assert;
+pub const util = @import("util.zig");

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -10,8 +10,8 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 const MultiArrayList = std.MultiArrayList;
 
-const isEven = struct {
-    pub fn filter(_: isEven, num: u8) bool {
+const IsEven = struct {
+    pub fn filter(_: IsEven, num: u8) bool {
         return num % 2 == 0;
     }
 };
@@ -152,7 +152,7 @@ test "cloneReset" {
 }
 test "where" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3, 4, 5, 6 });
-    var filtered: Iter(u8) = iter.where(&isEven{}, .none);
+    var filtered: Iter(u8) = iter.where(&IsEven{}, .none);
 
     var clone: Iter(u8) = try filtered.clone(testing.allocator);
     defer clone.deinit();
@@ -185,7 +185,7 @@ test "does the context seg-fault?" {
 }
 test "enumerateToOwnedSlice" {
     var inner: Iter(u8) = .from(&try util.range(u8, 1, 3));
-    var iter: Iter(u8) = inner.where(&isEven{}, .none);
+    var iter: Iter(u8) = inner.where(&IsEven{}, .none);
 
     try testing.expect(iter.len() == 3);
 
@@ -210,7 +210,7 @@ test "empty" {
     try testing.expect(iter.len() == 0);
     try testing.expect(iter.next() == null);
 
-    var next_iter = iter.where(&isEven{}, .none);
+    var next_iter = iter.where(&IsEven{}, .none);
 
     try testing.expect(next_iter.len() == 0);
     try testing.expect(next_iter.next() == null);
@@ -247,7 +247,7 @@ test "concat" {
 
         iter.reset();
 
-        var new_iter: Iter(u8) = iter.where(&isEven{}, .none);
+        var new_iter: Iter(u8) = iter.where(&IsEven{}, .none);
 
         try testing.expectEqual(9, new_iter.len());
         try testing.expect(new_iter.getIndex() == null);
@@ -351,7 +351,7 @@ test "any" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 3, 5 });
     defer iter.deinit();
 
-    var result: ?u8 = iter.any(&isEven{});
+    var result: ?u8 = iter.any(IsEven{});
     try testing.expect(result == null);
 
     // should have scrolled back
@@ -429,7 +429,7 @@ test "clone" {
 }
 test "clone with where static" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3, 4, 5, 6 });
-    var outer: Iter(u8) = iter.where(&isEven{}, .none);
+    var outer: Iter(u8) = iter.where(&IsEven{}, .none);
 
     var result: ?u8 = outer.next();
     try testing.expectEqual(2, result);
@@ -823,12 +823,12 @@ test "set index" {
     try transformed.setIndex(5);
     try testing.expectEqualStrings("6", transformed.next().?);
 
-    var filtered: Iter(u8) = iter.where(&isEven{}, .none);
+    var filtered: Iter(u8) = iter.where(&IsEven{}, .none);
     try testing.expectError(error.NoIndexing, filtered.setIndex(0));
 }
 test "allocator mix n match" {
     var iter: Iter(u8) = .from(&try util.range(u8, 1, 8));
-    var filtered: Iter(u8) = iter.where(&isEven{}, .none);
+    var filtered: Iter(u8) = iter.where(&IsEven{}, .none);
 
     var arena: ArenaAllocator = .init(testing.allocator);
     defer arena.deinit();
@@ -846,7 +846,7 @@ test "allocator mix n match" {
     var clone4 = try iter.clone(arena2.allocator());
     defer clone4.deinit();
 
-    var filtered2 = clone4.where(&isEven{}, .none);
+    var filtered2 = clone4.where(&IsEven{}, .none);
 
     var clone5 = try filtered2.clone(arena2.allocator());
     defer clone5.deinit();
@@ -854,13 +854,13 @@ test "allocator mix n match" {
 test "filterNext()" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
     var moved: usize = undefined;
-    try testing.expectEqual(2, iter.filterNext(isEven{}, &moved));
+    try testing.expectEqual(2, iter.filterNext(IsEven{}, &moved));
     try testing.expectEqual(2, moved); // moved 2 elements
 
-    try testing.expectEqual(null, iter.filterNext(isEven{}, &moved));
+    try testing.expectEqual(null, iter.filterNext(IsEven{}, &moved));
     try testing.expectEqual(1, moved); // moved 1 element and then encountered end
 
-    try testing.expectEqual(null, iter.filterNext(isEven{}, &moved));
+    try testing.expectEqual(null, iter.filterNext(IsEven{}, &moved));
     try testing.expectEqual(0, moved); // did not move again
 }
 test "iter with optionals" {

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -9,6 +9,10 @@ const SplitIterator = std.mem.SplitIterator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 const MultiArrayList = std.MultiArrayList;
+const autoCompare = iter_z.autoCompare;
+const autoSum = iter_z.autoSum;
+const autoMin = iter_z.autoMin;
+const autoMax = iter_z.autoMax;
 
 const IsEven = struct {
     pub fn filter(_: IsEven, num: u8) bool {
@@ -325,7 +329,7 @@ test "orderBy" {
     const nums = [_]u8{ 2, 5, 7, 1, 6, 4, 3 };
 
     var inner: Iter(u8) = .from(&nums);
-    var iter: Iter(u8) = try inner.orderBy(testing.allocator, iter_z.autoCompare(u8), .asc);
+    var iter: Iter(u8) = try inner.orderBy(testing.allocator, autoCompare(u8), .asc);
     defer iter.deinit();
 
     var i: usize = 0;
@@ -337,7 +341,7 @@ test "orderBy" {
     try testing.expect(i == 7);
 
     var inner2: Iter(u8) = .from(&nums);
-    var iter2 = try inner2.orderBy(testing.allocator, iter_z.autoCompare(u8), .desc);
+    var iter2 = try inner2.orderBy(testing.allocator, autoCompare(u8), .desc);
     defer iter2.deinit();
 
     while (iter2.next()) |x| {
@@ -733,7 +737,7 @@ test "from other" {
 
         pub fn filter(self: @This(), s: []const u8) bool {
             var inner_iter: Iter(u8) = .from(s);
-            return !inner_iter.contains(self.char, iter_z.autoCompare(u8));
+            return !inner_iter.contains(self.char, autoCompare(u8));
         }
     };
 
@@ -875,15 +879,15 @@ test "iter with optionals" {
 }
 test "reduce auto sum" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
-    try testing.expectEqual(6, iter.reduce(iter_z.autoSum(u8)));
+    try testing.expectEqual(6, iter.reduce(autoSum(u8)));
 }
 test "reduce auto min" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
-    try testing.expectEqual(1, iter.reduce(iter_z.autoMin(u8)));
+    try testing.expectEqual(1, iter.reduce(autoMin(u8)));
 }
 test "reduce auto max" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });
-    try testing.expectEqual(3, iter.reduce(iter_z.autoMax(u8)));
+    try testing.expectEqual(3, iter.reduce(autoMax(u8)));
 }
 test "reverse" {
     var iter: Iter(u8) = .from(&[_]u8{ 1, 2, 3 });

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -928,60 +928,28 @@ test "multi array list" {
         str: []const u8,
     };
 
-    {
-        var list: MultiArrayList(S) = .empty;
-        defer list.deinit(testing.allocator);
-        try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
-        try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
+    var list: MultiArrayList(S) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
+    try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
 
-        var iter: Iter(S) = try .fromMulti(testing.allocator, list);
-        defer iter.deinit();
+    var iter: Iter(S) = .fromMulti(list);
 
-        var expected_tag: usize = 1;
-        while (iter.next()) |s| : (expected_tag += 1) {
-            try testing.expectEqual(expected_tag, s.tag);
-        }
-        expected_tag = 2;
-        while (iter.prev()) |s| : (expected_tag -= 1) {
-            try testing.expectEqual(expected_tag, s.tag);
-        }
-
-        var clone: Iter(S) = try iter.clone(testing.allocator);
-        defer clone.deinit();
-
-        _ = iter.next();
-        try testing.expectEqualStrings("AAA", clone.next().?.str);
-        try testing.expectEqualStrings("BBB", clone.next().?.str);
-        try testing.expectEqual(1, iter.getIndex());
-        try testing.expectEqual(2, clone.getIndex());
+    var expected_tag: usize = 1;
+    while (iter.next()) |s| : (expected_tag += 1) {
+        try testing.expectEqual(expected_tag, s.tag);
     }
-    // use locally scoped iterable
-    {
-        var list: MultiArrayList(S) = .empty;
-        defer list.deinit(testing.allocator);
-        try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
-        try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
-
-        var iterable: iter_z.MultiArrayListIterable(S) = .init(list);
-        var iter: Iter(S) = iterable.iter();
-        // don't need to deinit
-
-        var expected_tag: usize = 1;
-        while (iter.next()) |s| : (expected_tag += 1) {
-            try testing.expectEqual(expected_tag, s.tag);
-        }
-        expected_tag = 2;
-        while (iter.prev()) |s| : (expected_tag -= 1) {
-            try testing.expectEqual(expected_tag, s.tag);
-        }
-
-        var clone: Iter(S) = try iter.clone(testing.allocator);
-        defer clone.deinit();
-
-        _ = iter.next();
-        try testing.expectEqualStrings("AAA", clone.next().?.str);
-        try testing.expectEqualStrings("BBB", clone.next().?.str);
-        try testing.expectEqual(1, iter.getIndex());
-        try testing.expectEqual(2, clone.getIndex());
+    expected_tag = 2;
+    while (iter.prev()) |s| : (expected_tag -= 1) {
+        try testing.expectEqual(expected_tag, s.tag);
     }
+
+    var clone: Iter(S) = try iter.clone(testing.allocator);
+    // defer clone.deinit();
+
+    _ = iter.next();
+    try testing.expectEqualStrings("AAA", clone.next().?.str);
+    try testing.expectEqualStrings("BBB", clone.next().?.str);
+    try testing.expectEqual(1, iter.getIndex());
+    try testing.expectEqual(2, clone.getIndex());
 }

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -945,7 +945,8 @@ test "multi array list" {
     }
 
     var clone: Iter(S) = try iter.clone(testing.allocator);
-    // defer clone.deinit();
+    // also don't TECHNICALLY need to deinit this since it doesn't really clone anything
+    defer clone.deinit();
 
     _ = iter.next();
     try testing.expectEqualStrings("AAA", clone.next().?.str);


### PR DESCRIPTION
Largely a simplification of using `MultiArrayList(T)`. Also built with zig 0.14.1.