### PR TITLE
From linked list

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Call `deinit()` to free.
 
 Parameters:
 - `allocator` to allocate the slice of all the lists elements
-- `linkage` to specify if the list is singly linked or doubly linked
 - `node_field_name` is used to get `*T` from `@fieldParentPtr()` since linked lists in the std lib are intrusive
+- `linkage` to specify if the list is singly linked or doubly linked
 - `list` is the list itself
 
 ```zig
@@ -364,7 +364,7 @@ test "from linked list" {
         a.node.insertAfter(&b.node);
         b.node.insertAfter(&c.node);
 
-        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .single, "node", list);
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .single, list);
         defer iter.deinit();
 
         try testing.expectEqual(1, iter.next().?.val);
@@ -388,7 +388,7 @@ test "from linked list" {
         list.append(&b.node);
         list.append(&c.node);
 
-        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .double, "node", list);
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .double, list);
         defer iter.deinit();
 
         try testing.expectEqual(1, iter.next().?.val);

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ while (iter.prev()) |s| : (expected_tag -= 1) {
 ### `fromLinkedList()`
 Instantiate an iterator from a linked list (singly or doubly linked).
 Since the length of either type of linked list cannot be determined without iterating through all the nodes, the nodes are saved into a slice that the resulting `Iter(T)` owns.
+Therefore, this iterator is snapshot of a given linked list. If it changes at all, the iterator will not represent that.
 Call `deinit()` to free.
 
 Parameters:

--- a/build.zig
+++ b/build.zig
@@ -9,14 +9,12 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
         .root_source_file = b.path("src/iter.zig"),
+        .error_tracing = true,
     });
 
     {
         const iter_test: *Build.Step.Compile = b.addTest(.{
-            .root_source_file = b.path("test/iter_tests.zig"),
-            .target = target,
-            .optimize = optimize,
-            .error_tracing = true,
+            .root_module = iter_module,
         });
         iter_test.root_module.addImport("iter_z", iter_module);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .fingerprint = 0x4415db88c6a4829c,
     .name = .iter_z,
-    .version = "0.3.0",
+    .version = "0.3.1-alpha",
     .dependencies = .{},
     .paths = .{""},
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.0-dev.936+fc2c1883b",
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,5 +4,5 @@
     .version = "0.3.1-alpha",
     .dependencies = .{},
     .paths = .{""},
-    .minimum_zig_version = "0.15.0-dev.936+fc2c1883b",
+    .minimum_zig_version = "0.15.0-dev.1034+bd97b6618",
 }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -649,6 +649,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Create `Iter(T)` from a linked list:
         /// Since the length of any linked list cannot be known without iterating through each node, we're simply allocating a slice to put all the nodes into.
+        /// Be sure to call `deinit()` to free the underlying slice.
         /// - `allocator` to allocate the slice of all the lists elements
         /// - `node_field_name` is used to get `*T` from `@fieldParentPtr()` since linked lists in the std lib are intrusive
         /// - `linkage` to specify if the list is singly linked or doubly linked

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -650,13 +650,13 @@ pub fn Iter(comptime T: type) type {
         /// Create `Iter(T)` from a linked list:
         /// Since the length of any linked list cannot be known without iterating through each node, we're simply allocating a slice to put all the nodes into.
         /// - `allocator` to allocate the slice of all the lists elements
-        /// - `linkage` to specify if the list is singly linked or doubly linked
         /// - `node_field_name` is used to get `*T` from `@fieldParentPtr()` since linked lists in the std lib are intrusive
+        /// - `linkage` to specify if the list is singly linked or doubly linked
         /// - `list` is the list itself
         pub fn fromLinkedList(
             allocator: Allocator,
-            comptime linkage: enum { single, double },
             comptime node_field_name: []const u8,
+            comptime linkage: enum { single, double },
             list: if (linkage == .single) SinglyLinkedList else DoublyLinkedList,
         ) Allocator.Error!Iter(T) {
             var elements: ArrayList(T) = .empty;

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -542,8 +542,8 @@ pub fn Iter(comptime T: type) type {
 
         /// Get the length of this iterator.
         ///
-        /// NOTE : This length is strictly a maximum. If the iterator has indexing, then the actual length will equal the number of elements returned by `next()`.
-        /// However, on concatenated or filtered iterators, the length becomes obscured, and only a maximum can be estimated.
+        /// NOTE : This length is strictly a maximum.
+        /// On concatenated or filtered iterators, the length becomes obscured, and only a maximum can be estimated.
         pub fn len(self: Iter(T)) usize {
             return switch (self.variant) {
                 .slice => |s| s.elements.len,
@@ -651,7 +651,7 @@ pub fn Iter(comptime T: type) type {
         /// Since the length of any linked list cannot be known without iterating through each node, we're simply allocating a slice to put all the nodes into.
         /// - `allocator` to allocate the slice of all the lists elements
         /// - `linkage` to specify if the list is singly linked or doubly linked
-        /// - `node_field_name` is used to get `*T` from `@fieldParentPtr()` since linked lists in the std lib are intrusive.
+        /// - `node_field_name` is used to get `*T` from `@fieldParentPtr()` since linked lists in the std lib are intrusive
         /// - `list` is the list itself
         pub fn fromLinkedList(
             allocator: Allocator,

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -1215,6 +1215,7 @@ test "from linked list" {
         var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .single, list);
         defer iter.deinit();
 
+        try testing.expectEqual(3, iter.len());
         try testing.expectEqual(1, iter.next().?.val);
         try testing.expectEqual(2, iter.next().?.val);
         try testing.expectEqual(3, iter.next().?.val);
@@ -1239,9 +1240,38 @@ test "from linked list" {
         var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .double, list);
         defer iter.deinit();
 
+        try testing.expectEqual(3, iter.len());
         try testing.expectEqual(1, iter.next().?.val);
         try testing.expectEqual(2, iter.next().?.val);
         try testing.expectEqual(3, iter.next().?.val);
+        try testing.expectEqual(null, iter.next());
+    }
+}
+test "empty linked lists" {
+    // single
+    {
+        const S = struct {
+            val: u16,
+            node: SinglyLinkedList.Node = .{},
+        };
+
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .single, SinglyLinkedList{});
+        defer iter.deinit();
+
+        try testing.expectEqual(0, iter.len());
+        try testing.expectEqual(null, iter.next());
+    }
+    // double
+    {
+        const S = struct {
+            val: u16,
+            node: DoublyLinkedList.Node = .{},
+        };
+
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .double, DoublyLinkedList{});
+        defer iter.deinit();
+
+        try testing.expectEqual(0, iter.len());
         try testing.expectEqual(null, iter.next());
     }
 }

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -3,12 +3,13 @@ const iter_z = @import("iter_z");
 const util = iter_z.util;
 const testing = std.testing;
 const Iter = iter_z.Iter;
-const ContextOwnership = iter_z.ContextOwnership;
 const Allocator = std.mem.Allocator;
 const SplitIterator = std.mem.SplitIterator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 const MultiArrayList = std.MultiArrayList;
+const SinglyLinkedList = std.SinglyLinkedList;
+const DoublyLinkedList = std.DoublyLinkedList;
 const autoCompare = iter_z.autoCompare;
 const autoSum = iter_z.autoSum;
 const autoMin = iter_z.autoMin;
@@ -1192,5 +1193,55 @@ test "pagination with scroll + take" {
 
         try testing.expectEqual(0, page_iter.len());
         try testing.expectEqual(null, page_iter.next());
+    }
+}
+test "from linked list" {
+    // single
+    {
+        const S = struct {
+            val: u16,
+            node: SinglyLinkedList.Node = .{},
+        };
+
+        var a: S = .{ .val = 1 };
+        var b: S = .{ .val = 2 };
+        var c: S = .{ .val = 3 };
+
+        var list: SinglyLinkedList = .{};
+        list.prepend(&a.node);
+        a.node.insertAfter(&b.node);
+        b.node.insertAfter(&c.node);
+
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .single, "node", list);
+        defer iter.deinit();
+
+        try testing.expectEqual(1, iter.next().?.val);
+        try testing.expectEqual(2, iter.next().?.val);
+        try testing.expectEqual(3, iter.next().?.val);
+        try testing.expectEqual(null, iter.next());
+    }
+    // double
+    {
+        const S = struct {
+            val: u16,
+            node: DoublyLinkedList.Node = .{},
+        };
+
+        var a: S = .{ .val = 1 };
+        var b: S = .{ .val = 2 };
+        var c: S = .{ .val = 3 };
+
+        var list: DoublyLinkedList = .{};
+        list.append(&a.node);
+        list.append(&b.node);
+        list.append(&c.node);
+
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .double, "node", list);
+        defer iter.deinit();
+
+        try testing.expectEqual(1, iter.next().?.val);
+        try testing.expectEqual(2, iter.next().?.val);
+        try testing.expectEqual(3, iter.next().?.val);
+        try testing.expectEqual(null, iter.next());
     }
 }

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -1,3 +1,24 @@
+const std = @import("std");
+const iter_z = @import("iter_z");
+const util = iter_z.util;
+const testing = std.testing;
+const Iter = iter_z.Iter;
+const Allocator = std.mem.Allocator;
+const SplitIterator = std.mem.SplitIterator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const FixedBufferAllocator = std.heap.FixedBufferAllocator;
+const MultiArrayList = std.MultiArrayList;
+const SinglyLinkedList = std.SinglyLinkedList;
+const DoublyLinkedList = std.DoublyLinkedList;
+const autoCompare = iter_z.autoCompare;
+const autoSum = iter_z.autoSum;
+const autoMin = iter_z.autoMin;
+const autoMax = iter_z.autoMax;
+const filterContext = iter_z.filterContext;
+const transformContext = iter_z.transformContext;
+const accumulateContext = iter_z.accumulateContext;
+const compareContext = iter_z.compareContext;
+
 const is_even = struct {
     pub fn filter(_: is_even, num: u8) bool {
         return num % 2 == 0;
@@ -1254,24 +1275,3 @@ test "empty linked lists" {
         try testing.expectEqual(null, iter.next());
     }
 }
-
-const std = @import("std");
-const iter_z = @import("iter_z");
-const util = iter_z.util;
-const testing = std.testing;
-const Iter = iter_z.Iter;
-const Allocator = std.mem.Allocator;
-const SplitIterator = std.mem.SplitIterator;
-const ArenaAllocator = std.heap.ArenaAllocator;
-const FixedBufferAllocator = std.heap.FixedBufferAllocator;
-const MultiArrayList = std.MultiArrayList;
-const SinglyLinkedList = std.SinglyLinkedList;
-const DoublyLinkedList = std.DoublyLinkedList;
-const autoCompare = iter_z.autoCompare;
-const autoSum = iter_z.autoSum;
-const autoMin = iter_z.autoMin;
-const autoMax = iter_z.autoMax;
-const filterContext = iter_z.filterContext;
-const transformContext = iter_z.transformContext;
-const accumulateContext = iter_z.accumulateContext;
-const compareContext = iter_z.compareContext;

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -1,24 +1,3 @@
-const std = @import("std");
-const iter_z = @import("iter_z");
-const util = iter_z.util;
-const testing = std.testing;
-const Iter = iter_z.Iter;
-const Allocator = std.mem.Allocator;
-const SplitIterator = std.mem.SplitIterator;
-const ArenaAllocator = std.heap.ArenaAllocator;
-const FixedBufferAllocator = std.heap.FixedBufferAllocator;
-const MultiArrayList = std.MultiArrayList;
-const SinglyLinkedList = std.SinglyLinkedList;
-const DoublyLinkedList = std.DoublyLinkedList;
-const autoCompare = iter_z.autoCompare;
-const autoSum = iter_z.autoSum;
-const autoMin = iter_z.autoMin;
-const autoMax = iter_z.autoMax;
-const filterContext = iter_z.filterContext;
-const transformContext = iter_z.transformContext;
-const accumulateContext = iter_z.accumulateContext;
-const compareContext = iter_z.compareContext;
-
 const is_even = struct {
     pub fn filter(_: is_even, num: u8) bool {
         return num % 2 == 0;
@@ -1275,3 +1254,24 @@ test "empty linked lists" {
         try testing.expectEqual(null, iter.next());
     }
 }
+
+const std = @import("std");
+const iter_z = @import("iter_z");
+const util = iter_z.util;
+const testing = std.testing;
+const Iter = iter_z.Iter;
+const Allocator = std.mem.Allocator;
+const SplitIterator = std.mem.SplitIterator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const FixedBufferAllocator = std.heap.FixedBufferAllocator;
+const MultiArrayList = std.MultiArrayList;
+const SinglyLinkedList = std.SinglyLinkedList;
+const DoublyLinkedList = std.DoublyLinkedList;
+const autoCompare = iter_z.autoCompare;
+const autoSum = iter_z.autoSum;
+const autoMin = iter_z.autoMin;
+const autoMax = iter_z.autoMax;
+const filterContext = iter_z.filterContext;
+const transformContext = iter_z.transformContext;
+const accumulateContext = iter_z.accumulateContext;
+const compareContext = iter_z.compareContext;

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -1212,7 +1212,7 @@ test "from linked list" {
         a.node.insertAfter(&b.node);
         b.node.insertAfter(&c.node);
 
-        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .single, "node", list);
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .single, list);
         defer iter.deinit();
 
         try testing.expectEqual(1, iter.next().?.val);
@@ -1236,7 +1236,7 @@ test "from linked list" {
         list.append(&b.node);
         list.append(&c.node);
 
-        var iter: Iter(S) = try .fromLinkedList(testing.allocator, .double, "node", list);
+        var iter: Iter(S) = try .fromLinkedList(testing.allocator, "node", .double, list);
         defer iter.deinit();
 
         try testing.expectEqual(1, iter.next().?.val);


### PR DESCRIPTION
Adding the ability to instantiate `Iter(T)` from a linked list. This involved having to use 0.15.0-dev... from Zig to use the new linked list API. Came with some build adjustment as well.