### PR TITLE
Fix docs and filter next

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ _ = iter.next(); // 2
 Pass in a comparer function to order your iterator in ascending or descending order (unstable sorting).
 Returns the concrete type [OwnedSliceIterable](#ownedslice) as this allocates a slice owned by the resulting iterator, so be sure to call `deinit()`.
 Stable sorting is available via `orderByStable()`.
+
+Additionally, there are buffer-based ordering methods as well: `orderByBuf()` and `orderByBufStable()`, which return the [SliceIterable](#slice) concrete type.
 ```zig
 /// equivalent to `iter_z.autoCompare(u8)` -> written out as example
 /// see Auto Contexts section; default comparer function is available to numeric types
@@ -539,6 +541,8 @@ _ = iter.interface.contains(1, iter_z.autoCompare(u8)); // true
 Enumerate all elements to a buffer passed in from the current.
 If you wish to start at the beginning, be sure to call `reset()` beforehand.
 Returns a slice of the buffer or returns `error.NoSpaceLeft` if we've run out of space.
+
+Additionally can return a sorted slice with `toBufferSorted()` and `toBufferSortedStable()`.
 ```zig
 var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
 var buf: [5]u8 = undefined;

--- a/README.md
+++ b/README.md
@@ -481,7 +481,6 @@ while (iter.interface.transformNext(u32, Multiplier{ .factor = 2 })) |x| {
 
 ### `count()`
 Count the number of elements in your iterator with or without a filter.
-This differs from `len()` because it will count the exact number of remaining elements with all transformations applied.
 
 The filter context is like the one in `where()`: It must define the method `fn filter(@TypeOf(filter_context), T) bool`.
 It does not need to be a pointer since it's not being stored as a member of a structure.
@@ -627,8 +626,7 @@ _ = iter.interface.skip(3).next(); // 'f'
 ```
 
 ### `take()`
-Take `buf.len` elements and return new iterator from that buffer.
-If there are less elements than the buffer size, that will be reflected in `len()`, as only a fraction of the buffer will be referenced.
+Take up to `buf.len` elements and return new iterator from that buffer.
 ```zig
 var full_iter = Iter(u8).slice(&util.range(u8, 1, 200));
 var page: [20]u8 = undefined;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The latest release is `v0.3.0`, which leverages Zig 0.14.1.
 
 WARNING: `v0.3.0` is an older API than what's in the main branch.
 [Issue #10](https://github.com/MiahDrao97/iter_z/issues/10) resulted in a complete overhaul of the API's, removing the ability for the iterator's length to be known and to move backwards.
-These limitations allowed a lazy iterator implemenation to exist, and similar to the writergate re-write, the `Iter(T)` interface shifted from a `*anyopaque` + tagged union strategy to a `@fieldParentPtr()` strategy.
+Limiting the v-table allowed a lazy iterator implemenation to exist, and similar to the writergate re-write, the `Iter(T)` interface shifted from a `*anyopaque` + tagged union strategy to a `@fieldParentPtr()` strategy.
 This resulted in more flexibility, less code, and better performance in most cases.
 
 Once Zig 0.15.0 is released, then `v0.4.0` will be tagged.
@@ -330,7 +330,7 @@ Returns a concrete iterable source `Iter(T).Select(comptime TOther: type, compti
 The `select()` method assumes that the context defines the method `transform()`.
 If that's not the case, you can use [transformContext()](#context-helper-functions) to create a wrapper struct.
 ```zig
-const as_digit = struct {
+const digit_to_str = struct {
     var buffer: [4]u8 = undefined;
 
     pub fn transform(_: @This(), byte: u8) []const u8 {
@@ -339,7 +339,7 @@ const as_digit = struct {
 };
 
 var iter = Iter(u8).slice(&util.range(u8, 1, 6));
-var outer = iter.interface.select([]const u8, as_digit{});
+var outer = iter.interface.select([]const u8, digit_to_str{});
 while (outer.next()) |x| {
     // "1", "2", "3", "4", "5", "6"
 }
@@ -668,7 +668,7 @@ Context types generated for numerical types for convenience.
 Example usage:
 ```zig
 var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-_ = iter.reduce(iter_z.autoSum(u8)); // 6
+_ = iter.interface.reduce(iter_z.autoSum(u8)); // 6
 ```
 
 Here are the underlying contexts generated:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ In your build.zig.zon, add the following dependency:
 ```
 
 Get your hash from the following:
+
+If you're using Zig 0.14.1, use the latest tagged version. Keep in mind these API's are outdated with the main branch.
 ```
 zig fetch https://github.com/MiahDrao97/iter_z/archive/refs/tags/v0.3.0.tar.gz
+```
+
+Otherwise, I strongly recommend the main branch:
+```
+zig fetch https://github.com/MiahDrao97/iter_z/archive/main.tar.gz
 ```
 
 Finally, in your build.zig, import this module in your root module:

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -53,7 +53,7 @@ pub fn Iter(comptime T: type) type {
         /// Virtual table
         vtable: *const VTable(T),
         /// Not intended to be directly accessed by users.
-        /// When an error causes the iterator to drop the current result, it's saved here instead (example: `enumerateToBuffer()`).
+        /// When an error causes the iterator to drop the current result, it's saved here instead (example: `toBuffer()`).
         /// It's the responsibility of the implementations to use this missed value and/or clear it.
         _missed: ?T = null,
 
@@ -687,7 +687,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Take `buf.len` and return new iterator from that buffer.
         pub fn take(self: *Iter(T), buf: []T) SliceIterable {
-            const result: []T = self.enumerateToBuffer(buf) catch buf;
+            const result: []T = self.toBuffer(buf) catch buf;
             return slice(result);
         }
 
@@ -696,7 +696,7 @@ pub fn Iter(comptime T: type) type {
             const buf: []T = try allocator.alloc(T, amt);
             errdefer allocator.free(buf);
 
-            const result: []T = self.enumerateToBuffer(buf) catch buf;
+            const result: []T = self.toBuffer(buf) catch buf;
             if (result.len == 0) {
                 // segmentation fault otherwise
                 allocator.free(buf);
@@ -721,7 +721,7 @@ pub fn Iter(comptime T: type) type {
         /// Returns a slice of `buf`, containing the enumerated elements.
         /// If space on `buf` runs out, returns `error.NoSpaceLeft`.
         /// However, the buffer will still hold the elements encountered before running out of space.
-        pub fn enumerateToBuffer(self: *Iter(T), buf: []T) error{NoSpaceLeft}![]T {
+        pub fn toBuffer(self: *Iter(T), buf: []T) error{NoSpaceLeft}![]T {
             var i: usize = 0;
             while (self.next()) |x| : (i += 1) {
                 errdefer self._missed = x;

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -824,19 +824,13 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Find the next element that fulfills a given filter.
-        /// This *does* move the iterator forward, which is reported in the out parameter `moved_forward`.
-        /// NOTE : This method is preferred over `where()` when simply iterating with a filter.
         ///
         /// `filter_context` must define the method: `fn filter(@TypeOf(filter_context), T) bool`.
         pub fn filterNext(
             self: *Iter(T),
             filter_context: anytype,
-            moved_forward: *usize,
         ) ?T {
-            var moved: usize = 0;
-            defer moved_forward.* = moved;
             while (self.next()) |n| {
-                moved += 1;
                 if (filter_context.filter(n)) {
                     return n;
                 }
@@ -846,7 +840,6 @@ pub fn Iter(comptime T: type) type {
 
         /// Transform the next element from type `T` to type `TOther` (or return null if iteration is over)
         /// `transform_context` must define the method: `fn transform(@TypeOf(transform_context), T) TOther` (similar to `select()`).
-        /// NOTE : This method is preferred over `select()` when simply iterating with a transformation.
         pub fn transformNext(self: *Iter(T), comptime TOther: type, transform_context: anytype) ?TOther {
             return if (self.next()) |x|
                 transform_context.transform(x)
@@ -897,8 +890,7 @@ pub fn Iter(comptime T: type) type {
                     };
                 }
             };
-            var moved: usize = undefined;
-            return self.filterNext(Ctx{ .ctx_item = item, .inner = compare_context }, &moved) != null;
+            return self.filterNext(Ctx{ .ctx_item = item, .inner = compare_context }) != null;
         }
 
         /// Count the number of filtered items or simply count the items remaining.

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -554,18 +554,18 @@ test "from other - skip first" {
         try testing.expectEqual(null, iter.next());
     }
 }
-test "enumerate to buffer" {
+test "to buffer" {
     {
         var iter = Iter(u8).slice(&iter_z.range(u8, 1, 8));
         var buf1: [8]u8 = undefined;
 
-        const result: []u8 = try iter.interface.enumerateToBuffer(&buf1);
+        const result: []u8 = try iter.interface.toBuffer(&buf1);
         for (result, 1..) |x, i| {
             try testing.expectEqual(i, x);
         }
 
         var buf2: [4]u8 = undefined;
-        try testing.expectError(error.NoSpaceLeft, iter.reset().enumerateToBuffer(&buf2));
+        try testing.expectError(error.NoSpaceLeft, iter.reset().toBuffer(&buf2));
         for (buf2, 1..) |x, i| {
             try testing.expectEqual(i, x);
         }
@@ -576,7 +576,7 @@ test "enumerate to buffer" {
         var iter: Iter(u8) = .empty;
         var buf: [10]u8 = undefined;
 
-        const result: []u8 = try iter.enumerateToBuffer(&buf);
+        const result: []u8 = try iter.toBuffer(&buf);
         try testing.expectEqual(0, result.len);
     }
     {
@@ -586,11 +586,11 @@ test "enumerate to buffer" {
         defer clone.deinit();
 
         var buf: [10]u8 = undefined;
-        const enumerated: []const u8 = try clone.interface.enumerateToBuffer(&buf);
+        const enumerated: []const u8 = try clone.interface.toBuffer(&buf);
         for (enumerated, 1..) |actual, expected| try testing.expectEqual(expected, actual);
 
         var failing_buf: [4]u8 = undefined;
-        try testing.expectError(error.NoSpaceLeft, clone.reset().enumerateToBuffer(&failing_buf));
+        try testing.expectError(error.NoSpaceLeft, clone.reset().toBuffer(&failing_buf));
         for (failing_buf, 1..) |actual, expected| try testing.expectEqual(expected, actual);
         try testing.expectEqual(5, clone.next()); // should pick up the missed value
     }

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -597,15 +597,8 @@ test "enumerate to buffer" {
 }
 test "filterNext()" {
     var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-    var moved: usize = undefined;
-    try testing.expectEqual(2, iter.interface.filterNext(is_even{}, &moved));
-    try testing.expectEqual(2, moved); // moved 2 elements
-
-    try testing.expectEqual(null, iter.interface.filterNext(is_even{}, &moved));
-    try testing.expectEqual(1, moved); // moved 1 element and then encountered end
-
-    try testing.expectEqual(null, iter.interface.filterNext(is_even{}, &moved));
-    try testing.expectEqual(0, moved); // did not move again
+    try testing.expectEqual(2, iter.interface.filterNext(is_even{}));
+    try testing.expectEqual(null, iter.interface.filterNext(is_even{}));
 }
 test "iter with optionals" {
     var iter = Iter(?u8).slice(&[_]?u8{ 1, 2, null, 3 });


### PR DESCRIPTION
- Some typos in README
- `filterNext()` doesn't need the `moved` out parameter anymore because scrolling is not a thing
- added buffer alternatives to `orderBy()` and `toSortedSliceOwned()`