### PR TITLE
Prefer unmanaged patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ The latest release is `v0.4.0`, which leverages Zig 0.15.1.
     - [select()](#select)
     - [where()](#where)
     - [alloc()](#alloc)
-    - [allocReset()](#allocreset)
-    - [rawClone()](#rawclone)
     - [orderBy()](#orderby)
     - [peek()](#peek)
     - [last()](#last)
@@ -132,8 +130,8 @@ Removed methods:
 - `len()`: Iterators are lazy. Use `.count({})` to achieve this.
 - `prev()`: Again, because iterators are lazy, we only go forward.
 - `scroll()`: We can't very well scroll without a `prev()` method. Use `skip()` to move forward, or `.reset().skip(amt)` to calculate a backwards movement. In practice, I've never had to move backwards; only reset.
-- `clone()`: This still exists in the form of `rawClone()`. Similar to managed vs unmanaged structures, `rawClone()` gives you an unmanaged clone, while `alloc()` gives you a structure with the clone and the allocator.
-- `cloneReset()`: See `allocReset()`.
+- `clone()`: This still exists in the form of `alloc()`.
+- `cloneReset()`: Just removed. Use `alloc()` and then call `reset()` on the copy before any other iterator method.
 - `deinit()`: This was removed from the interface and only declared on concrete implemenations that own memory. In a similar vein, `deinitClone()` is meant to free a cloned iterator.
 - `any()`: Replaced with `peek()`. `any()` now is the function to instantiate an iterator from any type that defines a `next()` method.
 - `reverseReset()`: Since backwards movement is no longer available, the iterator has to enumerate to an owned slice. Already comes "reset" when you call `reverse()`.
@@ -399,30 +397,12 @@ Be sure to call `free()` to free the memory.
 This function is the next incarnation of `clone()` from this library's previous versions.
 ```zig
 var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-const iter_cpy: Iter(u8).Allocated = try iter.interface.alloc(testing.allocator);
+const iter_cpy: *Iter(u8) = try iter.interface.alloc(testing.allocator);
 defer iter_cpy.free();
 
 while (iter_cpy.next()) |n| {
     // 1, 2, 3
 }
-```
-
-### `allocReset()`
-Calls `alloc()` and then `reset()` on the newly allocated iterator.
-```zig
-var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-_ = iter.next(); // 1
-
-const iter_cpy: Iter(u8).Allocated = try iter.interface.allocReset(testing.allocator);
-defer iter_cpy.free();
-
-// allocated iterator has been reset (starting at 1 again)
-while (iter_cpy.next()) |n| {
-    // 1, 2, 3
-}
-
-// original is still in its same position
-_ = iter.next(); // 2
 ```
 
 ### `orderBy()`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The latest release is `v0.4.0`, which leverages Zig 0.15.1.
     - [rawClone()](#rawclone)
     - [orderBy()](#orderby)
     - [peek()](#peek)
+    - [last()](#last)
     - [filterNext()](#filternext)
     - [transformNext()](#transformnext)
     - [count()](#count)
@@ -204,13 +205,13 @@ while (iter.next()) |x| {
 ```
 
 ### `ownedSlice()`
-This iterator will own the slice passed in, so be sure to call `deinit()` to free that slice.
+This iterator will own the slice passed in, so be sure to call `free()` to free that slice.
 The iterator's concrete type is `Iter(T).OwnedSliceIterable`.
-Can optionally pass in a callback when `deinit()` is called, presumably to free memory held by items in the slice.
+Can optionally pass in a callback when `free()` is called, presumably to free memory held by items in the slice.
 ```zig
 const slice: []u8 = try allocator.dupe(u8, "asdf");
 var iter = Iter(u8).ownedSlice(allocator, slice, null);
-defer iter.deinit();
+defer iter.free();
 
 while (iter.next()) |x| {
     // 'a', 's', 'd', 'f'
@@ -392,18 +393,14 @@ while (evens.next()) |x| {
 
 ### `alloc()`
 Allocate the iterator for storage purposes or to create a clone.
-Returns the concrete type `Iter(T).Allocated`, but unlike the iterable sources, this is not a true implemention of `Iter(T)`.
-It's merely a holder of the allocator that created the clone and the resulting `*Iter(T)`.
-Be sure to call `deinit()` to free the memory.
-
-There are two functions in `VTable(T)` that this method leverages: One to create the clone and another to deinitialize the clone.
-See more info in the [extensibility](#extensibility) section.
+Depending on the implementation, the contents may be copied as well.
+Be sure to call `free()` to free the memory.
 
 This function is the next incarnation of `clone()` from this library's previous versions.
 ```zig
 var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
 const iter_cpy: Iter(u8).Allocated = try iter.interface.alloc(testing.allocator);
-defer iter_cpy.deinit();
+defer iter_cpy.free();
 
 while (iter_cpy.next()) |n| {
     // 1, 2, 3
@@ -417,7 +414,7 @@ var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
 _ = iter.next(); // 1
 
 const iter_cpy: Iter(u8).Allocated = try iter.interface.allocReset(testing.allocator);
-defer iter_cpy.deinit();
+defer iter_cpy.free();
 
 // allocated iterator has been reset (starting at 1 again)
 while (iter_cpy.next()) |n| {
@@ -428,22 +425,9 @@ while (iter_cpy.next()) |n| {
 _ = iter.next(); // 2
 ```
 
-### `rawClone()`
-If you simply want an allocated `*Iter(T)` without the `Iter(T).Allocated` managed structure, you are free to use `rawClone()`.
-Be sure to call `deinitClone()` after use.
-```zig
-var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-const iter_cpy: *Iter(u8) = try iter.interface.rawClone(testing.allocator);
-defer iter_cpy.deinitClone(testing.allocator);
-
-while (iter_cpy.next()) |n| {
-    // 1, 2, 3
-}
-```
-
 ### `orderBy()`
 Pass in a comparer function to order your iterator in ascending or descending order (unstable sorting).
-Returns the concrete type [OwnedSliceIterable](#ownedslice) as this allocates a slice owned by the resulting iterator, so be sure to call `deinit()`.
+Returns the concrete type [OwnedSliceIterable](#ownedslice) as this allocates a slice owned by the resulting iterator, so be sure to call `free()`.
 Stable sorting is available via `orderByStable()`.
 
 Additionally, there are buffer-based ordering methods as well: `orderByBuf()` and `orderByBufStable()`, which return the [SliceIterable](#slice) concrete type.
@@ -466,7 +450,7 @@ const nums = [_]u8{ 8, 1, 4, 2, 6, 3, 7, 5 };
 var iter = Iter(u8).slice(&nums);
 
 var ordered = try iter.interface.orderBy(allocator, comparer{}, .asc); // or .desc
-defer ordered.deinit();
+defer ordered.free();
 
 while (ordered.next()) |x| {
     // 1, 2, 3, 4, 5, 6, 7, 8
@@ -494,6 +478,14 @@ _ = iter.interface.peek({}); // 'b'
 
 _ = iter.interface.peek(is_numeric{})); // '1'
 _ = iter.next(); // returns '1' again
+```
+
+### `last()`
+Iterates until the last element and returns that last element.
+Can return `null` if the iterator is empty or its iteration is already complete.
+```zig
+var iter = Iter(u8).slice("abc");
+_ = iter.interface.last(); // 'c'
 ```
 
 ### `filterNext()`
@@ -607,7 +599,7 @@ _ = iter.next(); // 3 is the next element after our error
 
 ### `toOwnedSlice()`
 Allocate a slice and enumerate all elements to it from the current offset.
-This will not free the iterator if it owns any memory, so you'll still have to call `deinit()` on it if it does.
+This will not free the iterator if it owns any memory, so you'll still have to call `free()` on it if it does.
 Caller owns the slice. If you wish to start enumerating at the beginning, be sure to call `reset()` beforehand.
 
 Additionally can return a sorted slice with `toOwnedSliceSorted()` and `toOwnedSliceSortedStable()`.
@@ -662,11 +654,11 @@ _ = iter.interface.reduce(sum{}); // 6
 
 ### `reverse()`
 Enumerates all the items into a slice and reverses the slice.
-Resulting iterator is another instance of [OwnedSliceIterable](#ownedslice), so be sure to call `deinit()`.
+Resulting iterator is another instance of [OwnedSliceIterable](#ownedslice), so be sure to call `free()`.
 ```zig
 var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
 var reversed = iter.interface.reverse();
-defer reversed.deinit();
+defer reversed.free();
 
 while (reversed.next()) |x| {
     // 3, 2, 1
@@ -702,14 +694,14 @@ while (page_iter.next()) |x| {
 
 ### `takeAlloc()`
 Similar to `take()`, except allocating memory rather than using a buffer.
-Returns concrete type [OwnedSliceIterable](#ownedslice), so don't forget to call `deinit()`.
+Returns concrete type [OwnedSliceIterable](#ownedslice), so don't forget to call `free()`.
 If there are less elements than the size passed in, the slice will be pared down to the exact number of elements returned.
 ```zig
 const page_size: usize = 20;
 var full_iter = Iter(u8).slice(&util.range(u8, 1, 200));
 var page_no: usize = 0;
 var page_iter = try full_iter.interface.skip(page_no * page_size).takeAlloc(testing.allocator, page_size);
-defer page_iter.deinit();
+defer page_iter.free();
 
 var expected: usize = 1;
 while (page_iter.next()) |x| {
@@ -718,7 +710,7 @@ while (page_iter.next()) |x| {
 
 page_no += 2;
 expected += page_size;
-page_iter.deinit();
+page_iter.free();
 page_iter = try full_iter.reset().skip(page_no * page_size).takeAlloc(testing.allocator, page_size);
 while (page_iter.next()) |x| {
     // third page: expecting values 41-60
@@ -826,40 +818,40 @@ You only need to implement `VTable(T)`, and you're set.
 pub fn VTable(comptime T: type) type {
     return struct {
         /// Get the next element or null if iteration is over.
-        next_fn: *const fn (*Iter(T)) ?T,
+        nextFn: *const fn (*Iter(T)) ?T,
         /// Reset the iterator the beginning. Should return the interface.
-        reset_fn: *const fn (*Iter(T)) *Iter(T),
-        /// Clone the iterator.
-        /// This is called by `Iter(T).alloc()` and the result will be given to the resulting `Iter(T).Allocated` instance.
-        clone_fn: *const fn (*Iter(T), Allocator) Allocator.Error!*Iter(T),
-        /// This implementation is for de-initializing a clone created with `clone_fn`.
-        /// Will be called by `Iter(T).Allocated.deinit()`.
-        deinit_clone_fn: *const fn (*Iter(T), Allocator) void,
+        resetFn: *const fn (*Iter(T)) *Iter(T),
+        /// Clone the iterator and potentially its contents, depending on the implementation.
+        allocFn: *const fn (*Iter(T), Allocator) Allocator.Error!*Iter(T),
+        /// This implementation is for freeing all memory created with `allocFn`
+        freeFn: *const fn (*Iter(T), Allocator) void,
 
         /// This is provided for a convenient default implementation:
         /// Simply assumes that the `*Iter(T)` is a property named "interface" contained on the concrete type.
         /// Creates `*TConcrete` and copies its value from the original.
-        pub inline fn defaultCloneFn(comptime TConcrete: type) fn (*Iter(T), Allocator) Allocator.Error!*Iter(T) {
+        /// Elements are not copied, as we're assuming they're not owned.
+        pub inline fn defaultAllocFn(comptime TConcrete: type) fn (*Iter(T), Allocator) Allocator.Error!*Iter(T) {
             return struct {
-                pub fn clone(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+                fn alloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
                     const c: *TConcrete = try allocator.create(TConcrete);
                     c.* = concrete.*;
                     return @as(*Iter(T), &c.interface);
                 }
-            }.clone;
+            }.alloc;
         }
 
         /// This is provided for a convenient default implementation:
         /// Simply assumes that the `*Iter(T)` is a property named "interface" contained on the concrete type.
         /// Destroys the pointer to the concrete type.
-        pub inline fn defaultDeinitCloneFn(comptime TConcrete: type) fn (*Iter(T), Allocator) void {
+        /// Elements are not freed, as we're assuming they're not owned.
+        pub inline fn defaultFreeFn(comptime TConcrete: type) fn (*Iter(T), Allocator) void {
             return struct {
-                pub fn deinit(iter: *Iter(T), allocator: Allocator) void {
+                fn free(iter: *Iter(T), allocator: Allocator) void {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
                     allocator.destroy(concrete);
                 }
-            }.deinit;
+            }.free;
         }
     };
 }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -9,40 +9,40 @@
 pub fn VTable(comptime T: type) type {
     return struct {
         /// Get the next element or null if iteration is over.
-        next_fn: *const fn (*Iter(T)) ?T,
+        nextFn: *const fn (*Iter(T)) ?T,
         /// Reset the iterator the beginning. Should return the interface.
-        reset_fn: *const fn (*Iter(T)) *Iter(T),
-        /// Clone the iterator.
-        /// This is called by `Iter(T).alloc()` and the result will be given to the resulting `Iter(T).Allocated` instance.
-        clone_fn: *const fn (*Iter(T), Allocator) Allocator.Error!*Iter(T),
-        /// This implementation is for de-initializing a clone created with `clone_fn`.
-        /// Will be called by `Iter(T).Allocated.deinit()`.
-        deinit_clone_fn: *const fn (*Iter(T), Allocator) void,
+        resetFn: *const fn (*Iter(T)) *Iter(T),
+        /// Clone the iterator and potentially its contents, depending on the implementation.
+        allocFn: *const fn (*Iter(T), Allocator) Allocator.Error!*Iter(T),
+        /// This implementation is for freeing all memory created with `allocFn`
+        freeFn: *const fn (*Iter(T), Allocator) void,
 
         /// This is provided for a convenient default implementation:
         /// Simply assumes that the `*Iter(T)` is a property named "interface" contained on the concrete type.
         /// Creates `*TConcrete` and copies its value from the original.
-        pub inline fn defaultCloneFn(comptime TConcrete: type) fn (*Iter(T), Allocator) Allocator.Error!*Iter(T) {
+        /// Elements are not copied, as we're assuming they're not owned.
+        pub inline fn defaultAllocFn(comptime TConcrete: type) fn (*Iter(T), Allocator) Allocator.Error!*Iter(T) {
             return struct {
-                pub fn clone(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+                fn alloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
                     const c: *TConcrete = try allocator.create(TConcrete);
                     c.* = concrete.*;
                     return @as(*Iter(T), &c.interface);
                 }
-            }.clone;
+            }.alloc;
         }
 
         /// This is provided for a convenient default implementation:
         /// Simply assumes that the `*Iter(T)` is a property named "interface" contained on the concrete type.
         /// Destroys the pointer to the concrete type.
-        pub inline fn defaultDeinitCloneFn(comptime TConcrete: type) fn (*Iter(T), Allocator) void {
+        /// Elements are not freed, as we're assuming they're not owned.
+        pub inline fn defaultFreeFn(comptime TConcrete: type) fn (*Iter(T), Allocator) void {
             return struct {
-                pub fn deinit(iter: *Iter(T), allocator: Allocator) void {
+                fn free(iter: *Iter(T), allocator: Allocator) void {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
                     allocator.destroy(concrete);
                 }
-            }.deinit;
+            }.free;
         }
     };
 }
@@ -59,25 +59,25 @@ pub fn Iter(comptime T: type) type {
 
         /// Returns the next element or `null` if the iteration is over.
         pub inline fn next(self: *Iter(T)) ?T {
-            return self.vtable.next_fn(self);
+            return self.vtable.nextFn(self);
         }
 
         /// Reset the iterator to the beginning.
         /// Returns `self`.
         pub inline fn reset(self: *Iter(T)) *Iter(T) {
-            return self.vtable.reset_fn(self);
+            return self.vtable.resetFn(self);
         }
 
-        /// Allocate the interface (calls `clone_fn` from the v-table).
-        /// Call `deinit()` to free.
+        /// Allocate the interface, potentially cloning the contents, depending on the implementation.
+        /// Call `free()` after use.
         pub inline fn alloc(self: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
-            return try self.vtable.clone_fn(self, allocator);
+            return try self.vtable.allocFn(self, allocator);
         }
 
-        /// Deinitialize an allocated interface (calls `deinit_clone_fn` from the v-table).
+        /// Free an allocated interface (calls `freeFn` from the v-table).
         /// If you did not call `alloc()` on this iterator, this will invoke illegal behavior.
-        pub inline fn deinit(self: *Iter(T), allocator: Allocator) void {
-            self.vtable.deinit_clone_fn(self, allocator);
+        pub inline fn free(self: *Iter(T), allocator: Allocator) void {
+            self.vtable.freeFn(self, allocator);
         }
 
         const empty_iterable = struct {
@@ -89,20 +89,20 @@ pub fn Iter(comptime T: type) type {
                 return iter;
             }
 
-            fn clone(iter: *Iter(T), _: Allocator) Allocator.Error!*Iter(T) {
+            fn alloc(iter: *Iter(T), _: Allocator) Allocator.Error!*Iter(T) {
                 return iter;
             }
 
-            fn deinitClone(_: *Iter(T), _: Allocator) void {}
+            fn free(_: *Iter(T), _: Allocator) void {}
         };
 
         /// Empty iterator
         pub const empty: Iter(T) = .{
             .vtable = &.{
-                .next_fn = &empty_iterable.next,
-                .reset_fn = &empty_iterable.reset,
-                .clone_fn = &empty_iterable.clone,
-                .deinit_clone_fn = &empty_iterable.deinitClone,
+                .nextFn = &empty_iterable.next,
+                .resetFn = &empty_iterable.reset,
+                .allocFn = &empty_iterable.alloc,
+                .freeFn = &empty_iterable.free,
             },
         };
 
@@ -112,10 +112,10 @@ pub fn Iter(comptime T: type) type {
             idx: usize = 0,
             interface: Iter(T) = .{
                 .vtable = &.{
-                    .next_fn = &implNext,
-                    .reset_fn = &implReset,
-                    .clone_fn = &VTable(T).defaultCloneFn(SliceIterable),
-                    .deinit_clone_fn = &VTable(T).defaultDeinitCloneFn(SliceIterable),
+                    .nextFn = &implNext,
+                    .resetFn = &implReset,
+                    .allocFn = &VTable(T).defaultAllocFn(SliceIterable),
+                    .freeFn = &VTable(T).defaultFreeFn(SliceIterable),
                 },
             },
 
@@ -153,13 +153,13 @@ pub fn Iter(comptime T: type) type {
         pub const OwnedSliceIterable = struct {
             slice: []const T,
             idx: usize = 0,
-            on_deinit: ?*const fn (Allocator, []T) void = null,
+            on_free: ?*const fn (Allocator, []T) void = null,
             interface: Iter(T) = .{
                 .vtable = &.{
-                    .next_fn = &implNext,
-                    .reset_fn = &implReset,
-                    .clone_fn = &implClone,
-                    .deinit_clone_fn = &implDeinitClone,
+                    .nextFn = &implNext,
+                    .resetFn = &implReset,
+                    .allocFn = &implAlloc,
+                    .freeFn = &implFree,
                 },
             },
 
@@ -181,8 +181,9 @@ pub fn Iter(comptime T: type) type {
                 return &self.interface;
             }
 
-            pub fn deinit(self: *OwnedSliceIterable, allocator: Allocator) void {
-                if (self.on_deinit) |exec| {
+            /// Frees the underlying slice
+            pub fn free(self: *OwnedSliceIterable, allocator: Allocator) void {
+                if (self.on_free) |exec| {
                     exec(allocator, @constCast(self.slice));
                 }
                 if (self.slice.len > 0) {
@@ -200,7 +201,7 @@ pub fn Iter(comptime T: type) type {
                 return self.reset();
             }
 
-            fn implClone(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+            fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
                 const self: *OwnedSliceIterable = @fieldParentPtr("interface", iter);
                 const c: *OwnedSliceIterable = try allocator.create(OwnedSliceIterable);
                 errdefer allocator.destroy(c);
@@ -208,14 +209,14 @@ pub fn Iter(comptime T: type) type {
                 c.* = .{
                     .slice = try allocator.dupe(T, self.slice),
                     .idx = self.idx,
-                    .on_deinit = null, // NEVER copy this for clones; it's intended to be called once since it can result in double-frees if it's propagated everywhere
+                    .on_free = null, // NEVER copy this for clones; it's intended to be called once since it can result in double-frees if it's propagated everywhere
                 };
                 return &c.interface;
             }
 
-            fn implDeinitClone(iter: *Iter(T), allocator: Allocator) void {
+            fn implFree(iter: *Iter(T), allocator: Allocator) void {
                 const self: *OwnedSliceIterable = @fieldParentPtr("interface", iter);
-                self.deinit(allocator); // free slice
+                self.free(allocator); // free slice
                 allocator.destroy(self);
             }
         };
@@ -226,14 +227,14 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Initialize a `SliceIterable` that owns the slice.
-        /// Must call `deinit()` on the iterator.
+        /// Must call `free()` on the iterator.
         pub fn ownedSlice(
             s: []const T,
-            on_deinit: ?*const fn (Allocator, []T) void,
+            on_free: ?*const fn (Allocator, []T) void,
         ) OwnedSliceIterable {
             return .{
                 .slice = s,
-                .on_deinit = on_deinit,
+                .on_free = on_free,
             };
         }
 
@@ -248,10 +249,10 @@ pub fn Iter(comptime T: type) type {
                 idx: usize = 0,
                 interface: Iter(T) = .{
                     .vtable = &.{
-                        .next_fn = &implNext,
-                        .reset_fn = &implReset,
-                        .clone_fn = &VTable(T).defaultCloneFn(MultiArrayListIterable),
-                        .deinit_clone_fn = &VTable(T).defaultDeinitCloneFn(MultiArrayListIterable),
+                        .nextFn = &implNext,
+                        .resetFn = &implReset,
+                        .allocFn = &VTable(T).defaultAllocFn(MultiArrayListIterable),
+                        .freeFn = &VTable(T).defaultFreeFn(MultiArrayListIterable),
                     },
                 },
 
@@ -300,10 +301,10 @@ pub fn Iter(comptime T: type) type {
                 current_node: ?*List.Node,
                 interface: Iter(T) = .{
                     .vtable = &.{
-                        .next_fn = &implNext,
-                        .reset_fn = &implReset,
-                        .clone_fn = &VTable(T).defaultCloneFn(Self),
-                        .deinit_clone_fn = &VTable(T).defaultDeinitCloneFn(Self),
+                        .nextFn = &implNext,
+                        .resetFn = &implReset,
+                        .allocFn = &VTable(T).defaultAllocFn(Self),
+                        .freeFn = &VTable(T).defaultFreeFn(Self),
                     },
                 },
 
@@ -364,10 +365,10 @@ pub fn Iter(comptime T: type) type {
                 resetInstance: TContext,
                 interface: Iter(T) = .{
                     .vtable = &.{
-                        .next_fn = &implNext,
-                        .reset_fn = &implReset,
-                        .clone_fn = &VTable(T).defaultCloneFn(Self),
-                        .deinit_clone_fn = &VTable(T).defaultDeinitCloneFn(Self),
+                        .nextFn = &implNext,
+                        .resetFn = &implReset,
+                        .allocFn = &VTable(T).defaultAllocFn(Self),
+                        .freeFn = &VTable(T).defaultFreeFn(Self),
                     },
                 },
 
@@ -425,10 +426,10 @@ pub fn Iter(comptime T: type) type {
                 og: *Iter(T),
                 interface: Iter(T) = .{
                     .vtable = &.{
-                        .next_fn = &implNext,
-                        .reset_fn = &implReset,
-                        .clone_fn = &implClone,
-                        .deinit_clone_fn = &implDeinitClone,
+                        .nextFn = &implNext,
+                        .resetFn = &implReset,
+                        .allocFn = &implAlloc,
+                        .freeFn = &implFree,
                     },
                 },
 
@@ -460,7 +461,7 @@ pub fn Iter(comptime T: type) type {
                     return self.reset();
                 }
 
-                fn implClone(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+                fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
                     const self: *Self = @fieldParentPtr("interface", iter);
                     const c: *Self = try allocator.create(Self);
                     errdefer allocator.destroy(c);
@@ -472,9 +473,9 @@ pub fn Iter(comptime T: type) type {
                     return &c.interface;
                 }
 
-                fn implDeinitClone(iter: *Iter(T), allocator: Allocator) void {
+                fn implFree(iter: *Iter(T), allocator: Allocator) void {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    self.og.deinit(allocator);
+                    self.og.free(allocator);
                     allocator.destroy(self);
                 }
             };
@@ -492,10 +493,10 @@ pub fn Iter(comptime T: type) type {
                 og: *Iter(T),
                 interface: Iter(TOther) = .{
                     .vtable = &.{
-                        .next_fn = &implNext,
-                        .reset_fn = &implReset,
-                        .clone_fn = &implClone,
-                        .deinit_clone_fn = &implDeinitClone,
+                        .nextFn = &implNext,
+                        .resetFn = &implReset,
+                        .allocFn = &implAlloc,
+                        .freeFn = &implFree,
                     },
                 },
 
@@ -528,7 +529,7 @@ pub fn Iter(comptime T: type) type {
                     return self.reset();
                 }
 
-                fn implClone(iter: *Iter(TOther), allocator: Allocator) Allocator.Error!*Iter(TOther) {
+                fn implAlloc(iter: *Iter(TOther), allocator: Allocator) Allocator.Error!*Iter(TOther) {
                     const self: *Self = @fieldParentPtr("interface", iter);
                     const c: *Self = try allocator.create(Self);
                     errdefer allocator.destroy(c);
@@ -540,9 +541,9 @@ pub fn Iter(comptime T: type) type {
                     return &c.interface;
                 }
 
-                fn implDeinitClone(iter: *Iter(TOther), allocator: Allocator) void {
+                fn implFree(iter: *Iter(TOther), allocator: Allocator) void {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    self.og.deinit(allocator);
+                    self.og.free(allocator);
                     allocator.destroy(self);
                 }
             };
@@ -563,10 +564,10 @@ pub fn Iter(comptime T: type) type {
             idx: usize = 0,
             interface: Iter(T) = .{
                 .vtable = &.{
-                    .next_fn = &implNext,
-                    .reset_fn = &implReset,
-                    .clone_fn = &implClone,
-                    .deinit_clone_fn = &implDeinitClone,
+                    .nextFn = &implNext,
+                    .resetFn = &implReset,
+                    .allocFn = &implAlloc,
+                    .freeFn = &implFree,
                 },
             },
 
@@ -600,7 +601,7 @@ pub fn Iter(comptime T: type) type {
                 return self.reset();
             }
 
-            fn implClone(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+            fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
                 const self: *ConcatIterable = @fieldParentPtr("interface", iter);
                 const c: *ConcatIterable = try allocator.create(ConcatIterable);
                 errdefer allocator.destroy(c);
@@ -608,7 +609,7 @@ pub fn Iter(comptime T: type) type {
                 var succeses: usize = 0;
                 const c_sources: []*Iter(T) = try allocator.alloc(*Iter(T), self.sources.len);
                 errdefer {
-                    for (0..succeses) |i| c_sources[i].deinit(allocator);
+                    for (0..succeses) |i| c_sources[i].free(allocator);
                     allocator.free(c_sources);
                 }
 
@@ -624,9 +625,9 @@ pub fn Iter(comptime T: type) type {
                 return &c.interface;
             }
 
-            fn implDeinitClone(iter: *Iter(T), allocator: Allocator) void {
+            fn implFree(iter: *Iter(T), allocator: Allocator) void {
                 const self: *ConcatIterable = @fieldParentPtr("interface", iter);
-                for (self.sources) |source| source.deinit(allocator);
+                for (self.sources) |source| source.free(allocator);
                 allocator.free(self.sources);
                 allocator.destroy(self);
             }
@@ -673,8 +674,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Enumerates into `buf`, starting at `self`'s current `next()` call.
         /// Note this does not reset `self` but rather starts at the current offset, so you may want to call `reset()` beforehand.
-        /// This method will not deallocate `self`, which means the caller is resposible to call `deinit()` if necessary.
-        /// Also, caller must reset again if later enumeration is needed.
+        /// Caller must reset if later enumeration is needed.
         ///
         /// Returns a slice of `buf`, containing the enumerated elements.
         /// If space on `buf` runs out, returns `error.NoSpaceLeft`.
@@ -736,7 +736,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Enumerates into a new slice.
         /// Note this does not reset `self` but rather starts at the current offset, so you may want to call `reset()` beforehand.
-        /// Note that `self` may need to be deallocated via calling `deinit()` or reset again for later enumeration.
+        /// Note that `self` may need to be deallocated via calling `free()` or reset again for later enumeration.
         ///
         /// Caller owns the resulting slice.
         pub fn toOwnedSlice(self: *Iter(T), allocator: Allocator) Allocator.Error![]T {
@@ -753,7 +753,7 @@ pub fn Iter(comptime T: type) type {
         /// Enumerates into new sorted slice. This uses an unstable sorting algorithm.
         /// If stable sorting is required, use `toOwnedSliceSortedStable()`.
         /// Note this does not reset `self` but rather starts at the current offset, so you may want to call `reset()` beforehand.
-        /// Note that `self` may need to be deallocated via calling `deinit()` or reset again for later enumeration.
+        /// Note that `self` may need to be deallocated via calling `free()` or reset again for later enumeration.
         /// `compare_context` must define the method `fn compare(@TypeOf(compare_context), T, T) std.math.Order`.
         ///
         /// Caller owns the resulting slice.
@@ -774,7 +774,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Enumerates into new sorted slice, using a stable sorting algorithm.
         /// Note this does not reset `self` but rather starts at the current offset, so you may want to call `reset()` beforehand.
-        /// Note that `self` may need to be deallocated via calling `deinit()` or reset again for later enumeration.
+        /// Note that `self` may need to be deallocated via calling `free()` or reset again for later enumeration.
         /// `compare_context` must define the method `fn compare(@TypeOf(compare_context), T, T) std.math.Order`.
         ///
         /// Caller owns the resulting slice.
@@ -797,7 +797,7 @@ pub fn Iter(comptime T: type) type {
         /// This makes use of an unstable sorting algorith. If stable sorting is required, use `orderByStable()`.
         /// `compare_context` must define the method `fn compare(@TypeOf(compare_context), T, T) std.math.Order`.
         ///
-        /// This iterator needs its underlying slice freed by calling `deinit()`.
+        /// This iterator needs its underlying slice freed by calling `free()`.
         pub fn orderBy(
             self: *Iter(T),
             allocator: Allocator,
@@ -811,7 +811,7 @@ pub fn Iter(comptime T: type) type {
         /// Rebuilds the iterator into an ordered slice and returns an iterator that owns said slice.
         /// `compare_context` must define the method `fn compare(@TypeOf(compare_context), T, T) std.math.Order`.
         ///
-        /// This iterator needs its underlying slice freed by calling `deinit()`.
+        /// This iterator needs its underlying slice freed by calling `free()`.
         pub fn orderByStable(
             self: *Iter(T),
             allocator: Allocator,
@@ -868,6 +868,14 @@ pub fn Iter(comptime T: type) type {
                 return x;
             }
             return null;
+        }
+
+        /// Get the last element of the iterator or `null` if the iterator is empty or its iteration is over.
+        /// Must reset before using again.
+        pub fn last(self: *Iter(T)) ?T {
+            var x: ?T = null;
+            while (self.next()) |y| x = y;
+            return x;
         }
 
         /// Find the next element that fulfills a given filter.
@@ -990,7 +998,7 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Enumerates all the items into a slice and reverses it.
-        /// Resulting iterator owns the slice, so be sure to call `deinit()`.
+        /// Resulting iterator owns the slice, so be sure to call `free()`.
         pub fn reverse(self: *Iter(T), allocator: Allocator) Allocator.Error!OwnedSliceIterable {
             const items: []T = try self.toOwnedSlice(allocator);
             std.mem.reverse(T, items);

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -23,9 +23,9 @@ pub fn VTable(comptime T: type) type {
         /// Elements are not copied, as we're assuming they're not owned.
         pub inline fn defaultAllocFn(comptime TConcrete: type) fn (*Iter(T), Allocator) Allocator.Error!*Iter(T) {
             return struct {
-                fn alloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+                fn alloc(iter: *Iter(T), gpa: Allocator) Allocator.Error!*Iter(T) {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
-                    const c: *TConcrete = try allocator.create(TConcrete);
+                    const c: *TConcrete = try gpa.create(TConcrete);
                     c.* = concrete.*;
                     return @as(*Iter(T), &c.interface);
                 }
@@ -38,9 +38,9 @@ pub fn VTable(comptime T: type) type {
         /// Elements are not freed, as we're assuming they're not owned.
         pub inline fn defaultFreeFn(comptime TConcrete: type) fn (*Iter(T), Allocator) void {
             return struct {
-                fn free(iter: *Iter(T), allocator: Allocator) void {
+                fn free(iter: *Iter(T), gpa: Allocator) void {
                     const concrete: *TConcrete = @fieldParentPtr("interface", iter);
-                    allocator.destroy(concrete);
+                    gpa.destroy(concrete);
                 }
             }.free;
         }
@@ -70,14 +70,14 @@ pub fn Iter(comptime T: type) type {
 
         /// Allocate the interface, potentially cloning the contents, depending on the implementation.
         /// Call `free()` after use.
-        pub inline fn alloc(self: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
-            return try self.vtable.allocFn(self, allocator);
+        pub inline fn alloc(self: *Iter(T), gpa: Allocator) Allocator.Error!*Iter(T) {
+            return try self.vtable.allocFn(self, gpa);
         }
 
         /// Free an allocated interface (calls `freeFn` from the v-table).
         /// If you did not call `alloc()` on this iterator, this will invoke illegal behavior.
-        pub inline fn free(self: *Iter(T), allocator: Allocator) void {
-            self.vtable.freeFn(self, allocator);
+        pub inline fn free(self: *Iter(T), gpa: Allocator) void {
+            self.vtable.freeFn(self, gpa);
         }
 
         const empty_iterable = struct {
@@ -182,12 +182,12 @@ pub fn Iter(comptime T: type) type {
             }
 
             /// Frees the underlying slice
-            pub fn free(self: *OwnedSliceIterable, allocator: Allocator) void {
+            pub fn free(self: *OwnedSliceIterable, gpa: Allocator) void {
                 if (self.on_free) |exec| {
-                    exec(allocator, @constCast(self.slice));
+                    exec(gpa, @constCast(self.slice));
                 }
                 if (self.slice.len > 0) {
-                    allocator.free(self.slice);
+                    gpa.free(self.slice);
                 }
             }
 
@@ -201,23 +201,23 @@ pub fn Iter(comptime T: type) type {
                 return self.reset();
             }
 
-            fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+            fn implAlloc(iter: *Iter(T), gpa: Allocator) Allocator.Error!*Iter(T) {
                 const self: *OwnedSliceIterable = @fieldParentPtr("interface", iter);
-                const c: *OwnedSliceIterable = try allocator.create(OwnedSliceIterable);
-                errdefer allocator.destroy(c);
+                const c: *OwnedSliceIterable = try gpa.create(OwnedSliceIterable);
+                errdefer gpa.destroy(c);
 
                 c.* = .{
-                    .slice = try allocator.dupe(T, self.slice),
+                    .slice = try gpa.dupe(T, self.slice),
                     .idx = self.idx,
                     .on_free = null, // NEVER copy this for clones; it's intended to be called once since it can result in double-frees if it's propagated everywhere
                 };
                 return &c.interface;
             }
 
-            fn implFree(iter: *Iter(T), allocator: Allocator) void {
+            fn implFree(iter: *Iter(T), gpa: Allocator) void {
                 const self: *OwnedSliceIterable = @fieldParentPtr("interface", iter);
-                self.free(allocator); // free slice
-                allocator.destroy(self);
+                self.free(gpa); // free slice
+                gpa.destroy(self);
             }
         };
 
@@ -461,22 +461,22 @@ pub fn Iter(comptime T: type) type {
                     return self.reset();
                 }
 
-                fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+                fn implAlloc(iter: *Iter(T), gpa: Allocator) Allocator.Error!*Iter(T) {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    const c: *Self = try allocator.create(Self);
-                    errdefer allocator.destroy(c);
+                    const c: *Self = try gpa.create(Self);
+                    errdefer gpa.destroy(c);
 
                     c.* = .{
-                        .og = try self.og.alloc(allocator),
+                        .og = try self.og.alloc(gpa),
                         .context = self.context,
                     };
                     return &c.interface;
                 }
 
-                fn implFree(iter: *Iter(T), allocator: Allocator) void {
+                fn implFree(iter: *Iter(T), gpa: Allocator) void {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    self.og.free(allocator);
-                    allocator.destroy(self);
+                    self.og.free(gpa);
+                    gpa.destroy(self);
                 }
             };
         }
@@ -529,22 +529,22 @@ pub fn Iter(comptime T: type) type {
                     return self.reset();
                 }
 
-                fn implAlloc(iter: *Iter(TOther), allocator: Allocator) Allocator.Error!*Iter(TOther) {
+                fn implAlloc(iter: *Iter(TOther), gpa: Allocator) Allocator.Error!*Iter(TOther) {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    const c: *Self = try allocator.create(Self);
-                    errdefer allocator.destroy(c);
+                    const c: *Self = try gpa.create(Self);
+                    errdefer gpa.destroy(c);
 
                     c.* = .{
-                        .og = try self.og.alloc(allocator),
+                        .og = try self.og.alloc(gpa),
                         .context = self.context,
                     };
                     return &c.interface;
                 }
 
-                fn implFree(iter: *Iter(TOther), allocator: Allocator) void {
+                fn implFree(iter: *Iter(TOther), gpa: Allocator) void {
                     const self: *Self = @fieldParentPtr("interface", iter);
-                    self.og.free(allocator);
-                    allocator.destroy(self);
+                    self.og.free(gpa);
+                    gpa.destroy(self);
                 }
             };
         }
@@ -601,20 +601,20 @@ pub fn Iter(comptime T: type) type {
                 return self.reset();
             }
 
-            fn implAlloc(iter: *Iter(T), allocator: Allocator) Allocator.Error!*Iter(T) {
+            fn implAlloc(iter: *Iter(T), gpa: Allocator) Allocator.Error!*Iter(T) {
                 const self: *ConcatIterable = @fieldParentPtr("interface", iter);
-                const c: *ConcatIterable = try allocator.create(ConcatIterable);
-                errdefer allocator.destroy(c);
+                const c: *ConcatIterable = try gpa.create(ConcatIterable);
+                errdefer gpa.destroy(c);
 
                 var succeses: usize = 0;
-                const c_sources: []*Iter(T) = try allocator.alloc(*Iter(T), self.sources.len);
+                const c_sources: []*Iter(T) = try gpa.alloc(*Iter(T), self.sources.len);
                 errdefer {
-                    for (0..succeses) |i| c_sources[i].free(allocator);
-                    allocator.free(c_sources);
+                    for (0..succeses) |i| c_sources[i].free(gpa);
+                    gpa.free(c_sources);
                 }
 
                 for (c_sources, self.sources) |*c_iter, source| {
-                    c_iter.* = try source.alloc(allocator);
+                    c_iter.* = try source.alloc(gpa);
                     succeses += 1;
                 }
 
@@ -625,11 +625,11 @@ pub fn Iter(comptime T: type) type {
                 return &c.interface;
             }
 
-            fn implFree(iter: *Iter(T), allocator: Allocator) void {
+            fn implFree(iter: *Iter(T), gpa: Allocator) void {
                 const self: *ConcatIterable = @fieldParentPtr("interface", iter);
-                for (self.sources) |source| source.free(allocator);
-                allocator.free(self.sources);
-                allocator.destroy(self);
+                for (self.sources) |source| source.free(gpa);
+                gpa.free(self.sources);
+                gpa.destroy(self);
             }
         };
 
@@ -651,23 +651,23 @@ pub fn Iter(comptime T: type) type {
         }
 
         /// Take `amt` elements, allocating a slice owned by the returned iterator to store the results
-        pub fn takeAlloc(self: *Iter(T), allocator: Allocator, amt: usize) Allocator.Error!OwnedSliceIterable {
-            const buf: []T = try allocator.alloc(T, amt);
-            errdefer allocator.free(buf);
+        pub fn takeAlloc(self: *Iter(T), gpa: Allocator, amt: usize) Allocator.Error!OwnedSliceIterable {
+            const buf: []T = try gpa.alloc(T, amt);
+            errdefer gpa.free(buf);
 
             const result: []T = self.toBuffer(buf) catch buf;
             if (result.len == 0) {
                 // segmentation fault otherwise
-                allocator.free(buf);
+                gpa.free(buf);
                 return ownedSlice("", null);
             }
 
             if (result.len < buf.len) {
-                if (allocator.resize(buf, result.len)) {
+                if (gpa.resize(buf, result.len)) {
                     return ownedSlice(buf, null);
                 }
-                defer allocator.free(buf);
-                return ownedSlice(try allocator.dupe(T, result), null);
+                defer gpa.free(buf);
+                return ownedSlice(try gpa.dupe(T, result), null);
             }
             return ownedSlice(result, null);
         }
@@ -739,15 +739,15 @@ pub fn Iter(comptime T: type) type {
         /// Note that `self` may need to be deallocated via calling `free()` or reset again for later enumeration.
         ///
         /// Caller owns the resulting slice.
-        pub fn toOwnedSlice(self: *Iter(T), allocator: Allocator) Allocator.Error![]T {
-            var list: ArrayList(T) = try .initCapacity(allocator, 16);
-            errdefer list.deinit(allocator);
+        pub fn toOwnedSlice(self: *Iter(T), gpa: Allocator) Allocator.Error![]T {
+            var list: ArrayList(T) = try .initCapacity(gpa, 16);
+            errdefer list.deinit(gpa);
 
             while (self.next()) |x| {
                 errdefer self.missed = x;
-                try list.append(allocator, x);
+                try list.append(gpa, x);
             }
-            return try list.toOwnedSlice(allocator);
+            return try list.toOwnedSlice(gpa);
         }
 
         /// Enumerates into new sorted slice. This uses an unstable sorting algorithm.
@@ -759,11 +759,11 @@ pub fn Iter(comptime T: type) type {
         /// Caller owns the resulting slice.
         pub fn toOwnedSliceSorted(
             self: *Iter(T),
-            allocator: Allocator,
+            gpa: Allocator,
             compare_context: anytype,
             ordering: Ordering,
         ) Allocator.Error![]T {
-            const s: []T = try self.toOwnedSlice(allocator);
+            const s: []T = try self.toOwnedSlice(gpa);
             const sort_ctx: SortContext(T, @TypeOf(compare_context)) = .{
                 .ctx = compare_context,
                 .ordering = ordering,
@@ -780,11 +780,11 @@ pub fn Iter(comptime T: type) type {
         /// Caller owns the resulting slice.
         pub fn toOwnedSliceSortedStable(
             self: *Iter(T),
-            allocator: Allocator,
+            gpa: Allocator,
             compare_context: anytype,
             ordering: Ordering,
         ) Allocator.Error![]T {
-            const s: []T = try self.toOwnedSlice(allocator);
+            const s: []T = try self.toOwnedSlice(gpa);
             const sort_ctx: SortContext(T, @TypeOf(compare_context)) = .{
                 .ctx = compare_context,
                 .ordering = ordering,
@@ -800,11 +800,11 @@ pub fn Iter(comptime T: type) type {
         /// This iterator needs its underlying slice freed by calling `free()`.
         pub fn orderBy(
             self: *Iter(T),
-            allocator: Allocator,
+            gpa: Allocator,
             compare_context: anytype,
             ordering: Ordering,
         ) Allocator.Error!OwnedSliceIterable {
-            const s: []T = try self.toOwnedSliceSorted(allocator, compare_context, ordering);
+            const s: []T = try self.toOwnedSliceSorted(gpa, compare_context, ordering);
             return ownedSlice(s, null);
         }
 
@@ -814,11 +814,11 @@ pub fn Iter(comptime T: type) type {
         /// This iterator needs its underlying slice freed by calling `free()`.
         pub fn orderByStable(
             self: *Iter(T),
-            allocator: Allocator,
+            gpa: Allocator,
             compare_context: anytype,
             ordering: Ordering,
         ) Allocator.Error!OwnedSliceIterable {
-            const s: []T = try self.toOwnedSliceSortedStable(allocator, compare_context, ordering);
+            const s: []T = try self.toOwnedSliceSortedStable(gpa, compare_context, ordering);
             return ownedSlice(s, null);
         }
 
@@ -999,8 +999,8 @@ pub fn Iter(comptime T: type) type {
 
         /// Enumerates all the items into a slice and reverses it.
         /// Resulting iterator owns the slice, so be sure to call `free()`.
-        pub fn reverse(self: *Iter(T), allocator: Allocator) Allocator.Error!OwnedSliceIterable {
-            const items: []T = try self.toOwnedSlice(allocator);
+        pub fn reverse(self: *Iter(T), gpa: Allocator) Allocator.Error!OwnedSliceIterable {
+            const items: []T = try self.toOwnedSlice(gpa);
             std.mem.reverse(T, items);
             return ownedSlice(items, null);
         }

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -98,7 +98,7 @@ pub fn Iter(comptime T: type) type {
 
         /// Empty iterator
         pub const empty: Iter(T) = .{
-            .vtable = &VTable(T){
+            .vtable = &.{
                 .next_fn = &empty_iterable.next,
                 .reset_fn = &empty_iterable.reset,
                 .clone_fn = &empty_iterable.clone,
@@ -111,7 +111,7 @@ pub fn Iter(comptime T: type) type {
             slice: []const T,
             idx: usize = 0,
             interface: Iter(T) = .{
-                .vtable = &VTable(T){
+                .vtable = &.{
                     .next_fn = &implNext,
                     .reset_fn = &implReset,
                     .clone_fn = &VTable(T).defaultCloneFn(SliceIterable),
@@ -155,7 +155,7 @@ pub fn Iter(comptime T: type) type {
             idx: usize = 0,
             on_deinit: ?*const fn (Allocator, []T) void = null,
             interface: Iter(T) = .{
-                .vtable = &VTable(T){
+                .vtable = &.{
                     .next_fn = &implNext,
                     .reset_fn = &implReset,
                     .clone_fn = &implClone,
@@ -247,7 +247,7 @@ pub fn Iter(comptime T: type) type {
                 list: std.MultiArrayList(T),
                 idx: usize = 0,
                 interface: Iter(T) = .{
-                    .vtable = &VTable(T){
+                    .vtable = &.{
                         .next_fn = &implNext,
                         .reset_fn = &implReset,
                         .clone_fn = &VTable(T).defaultCloneFn(MultiArrayListIterable),
@@ -299,7 +299,7 @@ pub fn Iter(comptime T: type) type {
                 list: List,
                 current_node: ?*List.Node,
                 interface: Iter(T) = .{
-                    .vtable = &VTable(T){
+                    .vtable = &.{
                         .next_fn = &implNext,
                         .reset_fn = &implReset,
                         .clone_fn = &VTable(T).defaultCloneFn(Self),
@@ -363,7 +363,7 @@ pub fn Iter(comptime T: type) type {
                 inner: TContext,
                 resetInstance: TContext,
                 interface: Iter(T) = .{
-                    .vtable = &VTable(T){
+                    .vtable = &.{
                         .next_fn = &implNext,
                         .reset_fn = &implReset,
                         .clone_fn = &VTable(T).defaultCloneFn(Self),
@@ -424,7 +424,7 @@ pub fn Iter(comptime T: type) type {
                 context: TContext,
                 og: *Iter(T),
                 interface: Iter(T) = .{
-                    .vtable = &VTable(T){
+                    .vtable = &.{
                         .next_fn = &implNext,
                         .reset_fn = &implReset,
                         .clone_fn = &implClone,
@@ -491,7 +491,7 @@ pub fn Iter(comptime T: type) type {
                 context: TContext,
                 og: *Iter(T),
                 interface: Iter(TOther) = .{
-                    .vtable = &VTable(TOther){
+                    .vtable = &.{
                         .next_fn = &implNext,
                         .reset_fn = &implReset,
                         .clone_fn = &implClone,
@@ -562,7 +562,7 @@ pub fn Iter(comptime T: type) type {
             sources: []const *Iter(T),
             idx: usize = 0,
             interface: Iter(T) = .{
-                .vtable = &VTable(T){
+                .vtable = &.{
                     .next_fn = &implNext,
                     .reset_fn = &implReset,
                     .clone_fn = &implClone,

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -440,8 +440,8 @@ pub fn Iter(comptime T: type) type {
                         self.interface.missed = null;
                         return m;
                     }
-                    return blk: while (self.og.next()) |x| {
-                        if (filter(self.context, x)) break :blk x;
+                    return while (self.og.next()) |x| {
+                        if (filter(self.context, x)) break x;
                     } else null;
                 }
 
@@ -576,10 +576,10 @@ pub fn Iter(comptime T: type) type {
                     self.interface.missed = null;
                     return m;
                 }
-                return blk: while (self.idx < self.sources.len) : (self.idx += 1) {
+                return while (self.idx < self.sources.len) : (self.idx += 1) {
                     const current: *Iter(T) = self.sources[self.idx];
                     if (current.next()) |x| {
-                        break :blk x;
+                        break x;
                     }
                 } else null;
             }
@@ -885,8 +885,8 @@ pub fn Iter(comptime T: type) type {
             self: *Iter(T),
             filter_context: anytype,
         ) ?T {
-            return blk: while (self.next()) |n| {
-                if (filter_context.filter(n)) break :blk n;
+            return while (self.next()) |n| {
+                if (filter_context.filter(n)) break n;
             } else null;
         }
 
@@ -909,9 +909,7 @@ pub fn Iter(comptime T: type) type {
         ) error{MultipleElementsFound}!?T {
             const filterProvided: bool = switch (@typeInfo(@TypeOf(filter_context))) {
                 .void => false,
-                else => blk: {
-                    break :blk true;
-                },
+                else => true,
             };
 
             var found: ?T = null;
@@ -967,8 +965,8 @@ pub fn Iter(comptime T: type) type {
         ///
         /// `filter_context` must define the method: `fn filter(@TypeOf(filter_context), T) bool`.
         pub fn all(self: *Iter(T), filter_context: anytype) bool {
-            return blk: while (self.next()) |x| {
-                if (!filter_context.filter(x)) break :blk false;
+            return while (self.next()) |x| {
+                if (!filter_context.filter(x)) break false;
             } else true;
         }
 

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -931,7 +931,7 @@ pub fn Iter(comptime T: type) type {
         /// Determine if this iterator contains a specific `item`.
         /// `compare_context` must define the method: `fn compare(@TypeOf(compare_context), T, T) std.math.Order`.
         pub fn contains(self: *Iter(T), item: T, compare_context: anytype) bool {
-            const Ctx = struct {
+            const ctx: struct {
                 ctx_item: T,
                 inner: @TypeOf(compare_context),
 
@@ -941,8 +941,8 @@ pub fn Iter(comptime T: type) type {
                         else => false,
                     };
                 }
-            };
-            return self.filterNext(Ctx{ .ctx_item = item, .inner = compare_context }) != null;
+            } = .{ .ctx_item = item, .inner = compare_context };
+            return self.filterNext(ctx) != null;
         }
 
         /// Count the number of filtered items or simply count the items remaining.

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -79,14 +79,14 @@ test "make a copy" {
     try testing.expectEqual(2, iter.next());
 }
 test "where" {
-    const ctx = struct {
+    const ctx: struct {
         pub fn isEven(_: @This(), byte: u8) bool {
             return byte % 2 == 0;
         }
-    };
+    } = .{};
     var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3, 4, 5, 6 });
     var filtered = iter.interface.where(
-        filterContext(u8, ctx{}, ctx.isEven),
+        filterContext(u8, ctx, @TypeOf(ctx).isEven),
     );
     const clone: *Iter(u8) = try filtered.interface.alloc(testing.allocator);
     defer clone.deinit(testing.allocator);
@@ -101,7 +101,7 @@ test "where" {
     try testing.expectEqual(null, clone.next());
 }
 test "does the context seg-fault?" {
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3, 4, 5, 6 });
+    var iter = Iter(u8).slice(&iter_z.range(u8, 1, 6));
     const filtered: *Iter(u8) = try getEvensIter(testing.allocator, &iter.interface);
     defer filtered.deinit(testing.allocator);
 
@@ -120,7 +120,8 @@ test "does the context seg-fault?" {
 test "toOwnedSlice" {
     {
         var inner = Iter(u8).slice(&iter_z.range(u8, 1, 3));
-        var iter = inner.interface.where(is_even{});
+        const ctx: is_even = undefined;
+        var iter = inner.interface.where(ctx);
 
         var i: usize = 0;
         while (iter.next()) |x| : (i += 1) {
@@ -146,16 +147,17 @@ test "empty" {
     var iter: Iter(u8) = .empty;
     try testing.expect(iter.next() == null);
 
-    var next_iter = iter.where(is_even{});
+    const ctx: is_even = undefined;
+    var next_iter = iter.where(ctx);
     try testing.expect(next_iter.next() == null);
 }
 test "concat" {
     {
-        var iter1 = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-        var iter2 = Iter(u8).slice(&[_]u8{ 4, 5, 6 });
-        var iter3 = Iter(u8).slice(&[_]u8{ 7, 8, 9 });
+        var iter1 = Iter(u8).slice(&.{ 1, 2, 3 });
+        var iter2 = Iter(u8).slice(&.{ 4, 5, 6 });
+        var iter3 = Iter(u8).slice(&.{ 7, 8, 9 });
 
-        var iter = Iter(u8).concat(&[_]*Iter(u8){
+        var iter = Iter(u8).concat(&.{
             &iter1.interface,
             &iter2.interface,
             &iter3.interface,
@@ -176,7 +178,8 @@ test "concat" {
         }
         try testing.expectEqual(9, i);
 
-        var new_iter = iter.reset().where(is_even{});
+        const ctx: is_even = undefined;
+        var new_iter = iter.reset().where(ctx);
         i = 0;
         while (new_iter.next()) |x| {
             i += 1;
@@ -186,7 +189,7 @@ test "concat" {
         try testing.expectEqual(4, i);
     }
     {
-        var other = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
+        var other = Iter(u8).slice(&.{ 1, 2, 3 });
         var empty: Iter(u8) = .empty;
         var iter = Iter(u8).concat(&.{ &other.interface, &empty });
 
@@ -243,7 +246,7 @@ test "order by buffer" {
         const nums: []const u16 = &iter_z.range(u16, 1, 10);
         var iter = Iter(u16).slice(nums);
         var buf: [10]u16 = undefined;
-        var shuffled = try iter.interface.orderByBuf(&buf, struct {
+        const ctx: struct {
             pub fn compare(_: @This(), x: u16, _: u16) std.math.Order {
                 const time: i128 = std.time.nanoTimestamp();
                 const trunc: u16 = @bitCast(@as(i16, @truncate(time)));
@@ -255,7 +258,8 @@ test "order by buffer" {
                 else
                     .eq;
             }
-        }{}, .asc);
+        } = .{};
+        var shuffled = try iter.interface.orderByBuf(&buf, ctx, .asc);
         var buf2: [10]u16 = undefined;
         var sorted = try shuffled.interface.orderByBuf(&buf2, autoCompare(u16), .asc);
         var expected: u16 = 1;
@@ -279,15 +283,6 @@ test "order by buffer" {
 }
 test "peek" {
     {
-        const is_numeric = struct {
-            pub fn filter(_: @This(), char: u8) bool {
-                return if (std.fmt.parseUnsigned(u8, &.{char}, 10)) |_|
-                    true
-                else |_|
-                    false;
-            }
-        };
-
         var iter = Iter(u8).slice("asdf123");
 
         try testing.expectEqual('a', iter.interface.peek({}));
@@ -295,7 +290,15 @@ test "peek" {
         try testing.expectEqual('s', iter.interface.peek({}));
         try testing.expectEqual('s', iter.next());
 
-        try testing.expectEqual('1', iter.interface.peek(is_numeric{}));
+        const is_numeric: struct {
+            pub fn filter(_: @This(), char: u8) bool {
+                return if (std.fmt.parseUnsigned(u8, &.{char}, 10)) |_|
+                    true
+                else |_|
+                    false;
+            }
+        } = .{};
+        try testing.expectEqual('1', iter.interface.peek(is_numeric));
         try testing.expectEqual('1', iter.next());
     }
     // edge case...
@@ -320,19 +323,26 @@ test "single" {
         }
     };
 
-    try testing.expectError(error.MultipleElementsFound, iter.reset().single(HasChar{ .char = 'r' }));
+    var ctx: HasChar = .{ .char = 'r' };
+    try testing.expectError(error.MultipleElementsFound, iter.reset().single(ctx));
 
-    var result: ?u8 = try iter.reset().single(HasChar{ .char = 'e' });
+    ctx.char = 'e';
+    var result: ?u8 = try iter.reset().single(ctx);
     try testing.expect(result.? == 'e');
 
-    result = try iter.reset().single(HasChar{ .char = 'x' });
+    ctx.char = 'x';
+    result = try iter.reset().single(ctx);
     try testing.expect(result == null);
 
-    result = try iter.reset().single(HasChar{ .char = 'e' });
+    ctx.char = 'e';
+    result = try iter.reset().single(ctx);
     try testing.expect(result.? == 'e');
 
-    try testing.expectEqual(null, try iter.reset().single(HasChar{ .char = 'x' }));
-    try testing.expectError(error.MultipleElementsFound, iter.reset().single(HasChar{ .char = 'r' }));
+    ctx.char = 'x';
+    try testing.expectEqual(null, try iter.reset().single(ctx));
+
+    ctx.char = 'r';
+    try testing.expectError(error.MultipleElementsFound, iter.reset().single(ctx));
     try testing.expectError(error.MultipleElementsFound, iter.reset().single({}));
 
     iter = Iter(u8).slice("");
@@ -342,7 +352,7 @@ test "single" {
     try testing.expectEqual('x', try iter.interface.single({}));
 }
 test "clone with select" {
-    const as_digit = struct {
+    const as_digit: struct {
         var representation: enum { hex, decimal } = undefined;
         var buffer: [16]u8 = undefined;
 
@@ -352,12 +362,12 @@ test "clone with select" {
                 .hex => std.fmt.bufPrint(&buffer, "0x{x:0>2}", .{byte}) catch unreachable,
             };
         }
-    };
+    } = .{};
 
     var iter = Iter(u8).slice(&iter_z.range(u8, 1, 6));
-    var outer = iter.interface.select([]const u8, as_digit{});
+    var outer = iter.interface.select([]const u8, as_digit);
 
-    as_digit.representation = .decimal;
+    @TypeOf(as_digit).representation = .decimal;
     try testing.expectEqualStrings("1", outer.next().?);
 
     const clone: *Iter([]const u8) = (try outer.interface.alloc(testing.allocator)).reset();
@@ -373,9 +383,9 @@ test "clone with select" {
     try testing.expectEqualStrings("4", outer.next().?);
 
     // test static behavior of context
-    as_digit.representation = .hex;
+    @TypeOf(as_digit).representation = .hex;
     try testing.expectEqualStrings("0x05", outer.next().?);
-    as_digit.representation = .decimal;
+    @TypeOf(as_digit).representation = .decimal;
     try testing.expectEqualStrings("6", outer.next().?);
     // check the clone
     try testing.expectEqualStrings("4", clone.next().?);
@@ -535,13 +545,18 @@ test "any" {
     const clone: *Iter([]const u8) = try iter.reset().alloc(testing.allocator);
     defer clone.deinit(testing.allocator);
 
-    try testing.expectEqual(1, clone.reset().count(StrLength{ .len = 1 }));
-    try testing.expectEqual(2, clone.reset().count(StrLength{ .len = 2 }));
+    var str_len_ctx: StrLength = .{ .len = 1 };
+    try testing.expectEqual(1, clone.reset().count(str_len_ctx));
+    str_len_ctx.len = 2;
+    try testing.expectEqual(2, clone.reset().count(str_len_ctx));
     try testing.expectEqual(6, clone.reset().count({}));
 
-    try testing.expect(clone.reset().all(HasNoChar{ .char = ',' }));
-    try testing.expect(!clone.reset().all(StrLength{ .len = 1 }));
-    try testing.expect(!clone.reset().all(StrLength{ .len = 2 }));
+    const has_no_char_ctx: HasNoChar = .{ .char = ',' };
+    try testing.expect(clone.reset().all(has_no_char_ctx));
+    str_len_ctx.len = 1;
+    try testing.expect(!clone.reset().all(str_len_ctx));
+    str_len_ctx.len = 2;
+    try testing.expect(!clone.reset().all(str_len_ctx));
 
     var reversed = try iter.interface.reverse(testing.allocator);
     defer reversed.deinit(testing.allocator);
@@ -668,8 +683,9 @@ test "to buffer" {
 }
 test "filterNext()" {
     var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-    try testing.expectEqual(2, iter.interface.filterNext(is_even{}));
-    try testing.expectEqual(null, iter.interface.filterNext(is_even{}));
+    const ctx: is_even = .{};
+    try testing.expectEqual(2, iter.interface.filterNext(ctx));
+    try testing.expectEqual(null, iter.interface.filterNext(ctx));
 }
 test "iter with optionals" {
     var iter = Iter(?u8).slice(&[_]?u8{ 1, 2, null, 3 });
@@ -682,28 +698,28 @@ test "iter with optionals" {
     }
 }
 test "fold" {
-    const ctx = struct {
+    const ctx: struct {
         fn add(_: @This(), accumulator: u16, item: u8) u16 {
             return accumulator + item;
         }
-    };
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
-    try testing.expectEqual(6, iter.interface.fold(u16, 0, accumulateContext(u8, u16, ctx{}, ctx.add)));
+    } = .{};
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
+    try testing.expectEqual(6, iter.interface.fold(u16, 0, accumulateContext(u8, u16, ctx, @TypeOf(ctx).add)));
 }
 test "reduce auto sum" {
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
     try testing.expectEqual(6, iter.interface.reduce(autoSum(u8)));
 }
 test "reduce auto min" {
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
     try testing.expectEqual(1, iter.interface.reduce(autoMin(u8)));
 }
 test "reduce auto max" {
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
     try testing.expectEqual(3, iter.interface.reduce(autoMax(u8)));
 }
 test "reverse" {
-    var iter = Iter(u8).slice(&[_]u8{ 1, 2, 3 });
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
     var reversed = try iter.interface.reverse(testing.allocator);
     defer reversed.deinit(testing.allocator);
     try testing.expectEqual(3, reversed.next());
@@ -720,8 +736,8 @@ test "multi array list" {
     {
         var list: MultiArrayList(S) = .empty;
         defer list.deinit(testing.allocator);
-        try list.append(testing.allocator, S{ .tag = 1, .str = "AAA" });
-        try list.append(testing.allocator, S{ .tag = 2, .str = "BBB" });
+        try list.append(testing.allocator, .{ .tag = 1, .str = "AAA" });
+        try list.append(testing.allocator, .{ .tag = 2, .str = "BBB" });
 
         var iter = Iter(S).multi(list);
 

--- a/test/iter_tests.zig
+++ b/test/iter_tests.zig
@@ -69,7 +69,7 @@ test "make a copy" {
     try testing.expect(iter.next() == 1);
 
     const iter_cpy: *Iter(u8) = (try iter.interface.alloc(testing.allocator)).reset();
-    defer iter_cpy.deinit(testing.allocator);
+    defer iter_cpy.free(testing.allocator);
 
     var i: usize = 1;
     while (iter_cpy.next()) |x| : (i += 1) {
@@ -89,7 +89,7 @@ test "where" {
         filterContext(u8, ctx, @TypeOf(ctx).isEven),
     );
     const clone: *Iter(u8) = try filtered.interface.alloc(testing.allocator);
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     try testing.expectEqual(2, filtered.next());
     try testing.expectEqual(2, clone.next());
@@ -103,10 +103,10 @@ test "where" {
 test "does the context seg-fault?" {
     var iter = Iter(u8).slice(&iter_z.range(u8, 1, 6));
     const filtered: *Iter(u8) = try getEvensIter(testing.allocator, &iter.interface);
-    defer filtered.deinit(testing.allocator);
+    defer filtered.free(testing.allocator);
 
     const clone: *Iter(u8) = try filtered.alloc(testing.allocator);
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     try testing.expectEqual(2, filtered.next());
     try testing.expectEqual(2, clone.next());
@@ -222,7 +222,7 @@ test "orderBy" {
 
     var inner = Iter(u8).slice(&nums);
     var iter = try inner.interface.orderBy(testing.allocator, autoCompare(u8), .asc);
-    defer iter.deinit(testing.allocator);
+    defer iter.free(testing.allocator);
 
     var i: usize = 0;
     while (iter.next()) |x| {
@@ -233,7 +233,7 @@ test "orderBy" {
 
     var inner2 = Iter(u8).slice(&nums);
     var iter2 = try inner2.interface.orderBy(testing.allocator, autoCompare(u8), .desc);
-    defer iter2.deinit(testing.allocator);
+    defer iter2.free(testing.allocator);
 
     while (iter2.next()) |x| : (i -= 1) {
         try testing.expectEqual(i, x);
@@ -371,7 +371,7 @@ test "clone with select" {
     try testing.expectEqualStrings("1", outer.next().?);
 
     const clone: *Iter([]const u8) = (try outer.interface.alloc(testing.allocator)).reset();
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     try testing.expectEqualStrings("2", outer.next().?);
     try testing.expectEqualStrings("3", outer.next().?);
@@ -417,15 +417,15 @@ test "Overlapping select edge cases" {
 
     var iter = Iter(u8).slice(&iter_z.range(u8, 1, 3));
     const clone: *Iter(u8) = try iter.interface.alloc(testing.allocator);
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     var doubler_ctx: Multiplier = .{ .factor = 2 };
     const doubler: *Iter(u32) = try getMultiplier(testing.allocator, &iter.interface, &doubler_ctx);
-    defer doubler.deinit(testing.allocator);
+    defer doubler.free(testing.allocator);
 
     var tripler_ctx: Multiplier = .{ .factor = 3 };
     const tripler: *Iter(u32) = try getMultiplier(testing.allocator, clone, &tripler_ctx);
-    defer tripler.deinit(testing.allocator);
+    defer tripler.free(testing.allocator);
 
     var result: ?u32 = doubler.next();
     try testing.expectEqual(2, result);
@@ -450,7 +450,7 @@ test "owned slice iterator" {
     for (slice, 0..) |*x, i| x.* = @as(u8, @truncate(i + 1));
 
     var iter = Iter(u8).ownedSlice(slice, null);
-    defer iter.deinit(testing.allocator);
+    defer iter.free(testing.allocator);
 
     var expected: u8 = 1;
     while (iter.next()) |x| {
@@ -476,19 +476,19 @@ test "owned slice iterator w/ args" {
     var iter = Iter([]const u8).ownedSlice(
         combined,
         &struct {
-            pub fn onDeinit(gpa: Allocator, slice: [][]const u8) void {
+            pub fn onFree(gpa: Allocator, slice: [][]const u8) void {
                 for (slice) |s| gpa.free(s);
             }
-        }.onDeinit,
+        }.onFree,
     );
-    defer iter.deinit(testing.allocator);
+    defer iter.free(testing.allocator);
 
     try testing.expectEqualStrings("blarf", iter.next().?);
     try testing.expectEqualStrings("asdf", iter.next().?);
     try testing.expectEqual(null, iter.next());
 
     const clone: *Iter([]const u8) = (try iter.interface.alloc(testing.allocator)).reset();
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     try testing.expectEqualStrings("blarf", clone.next().?);
     try testing.expectEqualStrings("asdf", clone.next().?);
@@ -543,7 +543,7 @@ test "any" {
     };
 
     const clone: *Iter([]const u8) = try iter.reset().alloc(testing.allocator);
-    defer clone.deinit(testing.allocator);
+    defer clone.free(testing.allocator);
 
     var str_len_ctx: StrLength = .{ .len = 1 };
     try testing.expectEqual(1, clone.reset().count(str_len_ctx));
@@ -559,7 +559,7 @@ test "any" {
     try testing.expect(!clone.reset().all(str_len_ctx));
 
     var reversed = try iter.interface.reverse(testing.allocator);
-    defer reversed.deinit(testing.allocator);
+    defer reversed.free(testing.allocator);
 
     try testing.expectEqualStrings("split", reversed.next().?);
     try testing.expectEqualStrings("to", reversed.next().?);
@@ -669,7 +669,7 @@ test "to buffer" {
         // enumerate to buffer with a clone
         var iter = Iter(u8).slice(&iter_z.range(u8, 1, 10));
         const clone: *Iter(u8) = try iter.interface.alloc(testing.allocator);
-        defer clone.deinit(testing.allocator);
+        defer clone.free(testing.allocator);
 
         var buf: [10]u8 = undefined;
         const enumerated: []const u8 = try clone.toBuffer(&buf);
@@ -721,12 +721,20 @@ test "reduce auto max" {
 test "reverse" {
     var iter = Iter(u8).slice(&.{ 1, 2, 3 });
     var reversed = try iter.interface.reverse(testing.allocator);
-    defer reversed.deinit(testing.allocator);
+    defer reversed.free(testing.allocator);
     try testing.expectEqual(3, reversed.next());
 
     var double_reversed = try reversed.interface.reverse(testing.allocator);
-    defer double_reversed.deinit(testing.allocator);
+    defer double_reversed.free(testing.allocator);
     try testing.expectEqual(1, double_reversed.next());
+}
+test "last" {
+    var iter = Iter(u8).slice(&.{ 1, 2, 3 });
+    try testing.expectEqual(3, iter.interface.last());
+
+    var cpy: *Iter(u8) = try iter.reset().alloc(testing.allocator);
+    defer cpy.free(testing.allocator);
+    try testing.expectEqual(3, cpy.last());
 }
 test "multi array list" {
     const S = struct {
@@ -782,7 +790,7 @@ test "pagination with skip + take" {
         var page_iter: Iter(u8).OwnedSliceIterable = try full_iter.interface
             .skip(page_no * page_size)
             .takeAlloc(testing.allocator, page_size);
-        defer page_iter.deinit(testing.allocator);
+        defer page_iter.free(testing.allocator);
 
         // first page: expecting values 1-20
         var expected: usize = 1;
@@ -793,7 +801,7 @@ test "pagination with skip + take" {
         // third page: expecting values 41-60
         page_no += 2;
         expected += page_size;
-        page_iter.deinit(testing.allocator);
+        page_iter.free(testing.allocator);
         page_iter = try full_iter.reset().skip(page_no * page_size).takeAlloc(testing.allocator, page_size);
         while (page_iter.next()) |actual| : (expected += 1) {
             try testing.expectEqual(expected, actual);
@@ -802,7 +810,7 @@ test "pagination with skip + take" {
     {
         var empty: Iter(u8) = .empty;
         var page_iter = try empty.takeAlloc(testing.allocator, 20);
-        defer page_iter.deinit(testing.allocator);
+        defer page_iter.free(testing.allocator);
 
         try testing.expectEqual(null, page_iter.next());
     }


### PR DESCRIPTION
Cleaning up a lot of methods and removing the `Allocated` structure. README cleanup, general code cleanup, and renaming some methods.